### PR TITLE
Handle empty dates

### DIFF
--- a/lib/prismic/json_parsers.rb
+++ b/lib/prismic/json_parsers.rb
@@ -36,7 +36,7 @@ module Prismic
         Prismic::Fragments::IntegrationField.new(json['value'])
       end
 
-      def boolean_field_parser(json) 
+      def boolean_field_parser(json)
         Prismic::Fragments::BooleanField.new(json['value'])
       end
 
@@ -84,7 +84,7 @@ module Prismic
         Prismic::Fragments::Text.new(json['value'])
       end
 
-      def separator_parser(json)
+      def separator_parser(_)
         Prismic::Fragments::Separator.new('')
       end
 
@@ -97,6 +97,8 @@ module Prismic
       end
 
       def date_parser(json)
+        return Prismic::Fragments::Text.new('') if json['value'].empty?
+
         Prismic::Fragments::Date.new(Time.parse(json['value']))
       end
 

--- a/spec/json_parsers_spec.rb
+++ b/spec/json_parsers_spec.rb
@@ -69,19 +69,38 @@ json
 end
 
 describe 'date_parser' do
-  before do
-    raw_json = <<json
-    {
-      "type": "date",
-      "value": "2013-09-19"
-    }
-json
-    @json = JSON.load(raw_json)
+  context 'when date response' do
+    before do
+      raw_json = <<~JSON
+        {
+          "type": "date",
+          "value": "2013-09-19"
+        }
+      JSON
+      @json = JSON.load(raw_json)
+    end
+
+    it "correctly parses Date objects" do
+      date = Prismic::JsonParser.date_parser(@json)
+      date.value.should == Time.new(2013, 9, 19)
+    end
   end
 
-  it "correctly parses Date objects" do
-    date = Prismic::JsonParser.date_parser(@json)
-    date.value.should == Time.new(2013, 9, 19)
+  context 'when date response not valid date' do
+    before do
+      raw_json = <<~JSON
+        {
+          "type": "date",
+          "value": ""
+        }
+      JSON
+      @json = JSON.load(raw_json)
+    end
+
+    it "returns empty string for the value" do
+      date = Prismic::JsonParser.date_parser(@json)
+      date.value.should == ''
+    end
   end
 end
 
@@ -496,7 +515,7 @@ describe 'structured_text_label_parser' do
 
 end
 
-describe 'boolean_field_parser' do 
+describe 'boolean_field_parser' do
   before do
     raw_json = <<json
     {


### PR DESCRIPTION
Currently when adding a date field to a template and calling a document that doesnt yet have that date filled out the SDK raises an error because it cant convert an empty string or `nil` to a Date/Time.
It will still raise an error for malformed dates.

This fixes it by returning an empty text fragment (so calling `.value`) still works.

I thought about a few other approaches but this seems to have the lowest impact. Open to feedback