### PR TITLE
docs: migrate docs from https://prismic.io/docs to Markdown files

### DIFF
--- a/docs-usage/01-integrate-prismic-with-an-existing-project-ruby.md
+++ b/docs-usage/01-integrate-prismic-with-an-existing-project-ruby.md
@@ -1,0 +1,82 @@
+# Integrate Prismic with an existing project
+
+If you already have a Ruby project that you want to integrate with Prismic, then you can simply add the Prismic Ruby development kit library as a dependency. Let's walk through all the steps to get Prismic integrated into your project!
+
+## 1. Create a content repository
+
+A content repository is where you define, edit and publish content.
+
+[**Create a new repository**](https://prismic.io/dashboard/new-repository/)
+
+Next you'll need to model your content, create your custom types, and publish some documents to your repository.
+
+Now, let's take a look at how to connect this new content with your project.
+
+## 2. Add the development kit as a dependency
+
+Let's add the Prismic Ruby kit as a dependency to your project.
+
+> Note: you will need to have both [Ruby](https://www.ruby-lang.org/en/downloads/) and [RubyGems](https://rubygems.org/pages/download) installed on your computer.
+
+Launch the terminal (command prompt or similar on Windows), point it to your project location and run the following command.
+
+```bash
+gem install prismic.io --pre
+```
+
+## 3. Require the prismic gem
+
+To add the gem as a dependency to your project with [Bundler](http://bundler.io/), you can add the following line in your Gemfile.
+
+```bash
+gem 'prismic.io', require: 'prismic'
+```
+
+## 4. Get the API and query your content
+
+Now we can query your Prismic repository and retrieve the content as shown below.
+
+```ruby
+api = Prismic.api('https://your-repo-name.cdn.prismic.io/api')
+response = api.query(Prismic::Predicates.at("document.type", "page"))
+documents = response.results
+```
+
+If you are using a private repository, then you'll need to include your access token like this.
+
+```ruby
+url = 'https://your-repo-name.cdn.prismic.io/api'
+token = 'MC5XUkynrnlvQUFIdVViSElaE--_ve-_ve-_vUUece71r77-9FgXvv73vv73uu73v'
+api = Prismic.api(url, token)
+response = api.query(Prismic::Predicates.at("document.type", "page"))
+documents = response.results
+```
+
+To learn more about querying the API and explore the many ways to retrieve your content, check out the [How to Query the API](../02-query-the-api/01-how-to-query-the-api.md) page.
+
+### Pagination of API Results
+
+When querying a Prismic repository, your results will be paginated. By default, there are 20 documents per page in the results. You can read more about how to manipulate the pagination in the [Pagination for Results](../02-query-the-api/16-pagination-for-results.md) page.
+
+## 5. Add the queried content to your templates
+
+Once you've retrieved your content, you can include it in your template using the helper functions in the Ruby development kit. Here's a simple example.
+
+```html
+<div class="content">
+   
+  <h1><%= @document['page.title'].as_text() %></h1>
+   <img src="<%= @document['page.image'].url %>" />
+   <%= @document['page.description'].as_html(nil).html_safe %>
+</div>
+```
+
+You can read more about templating your content in the Templating section of the documentation. There you will find explanations and examples of how to template each content field type.
+
+## 6. Take advantage of Previews and the Prismic Toolbar
+
+In order to take full advantage of Prismic's features, check out the[ Previews and the Prismic Toolbar](../04-beyond-the-api/02-previews-and-the-toolbar.md) page. There you will find the steps needed to add these features to your own Ruby app.
+
+## And your Prismic journey begins!
+
+You should have all the tools now to really dig into your Ruby project. We invite you to further explore the docs to learn how to define your Custom Types, query the API, and add your content to your templates.

--- a/docs-usage/01-integrate-prismic-with-an-existing-project-ruby.md
+++ b/docs-usage/01-integrate-prismic-with-an-existing-project-ruby.md
@@ -52,11 +52,11 @@ response = api.query(Prismic::Predicates.at("document.type", "page"))
 documents = response.results
 ```
 
-To learn more about querying the API and explore the many ways to retrieve your content, check out the [How to Query the API](../02-query-the-api/01-how-to-query-the-api.md) page.
+To learn more about querying the API and explore the many ways to retrieve your content, check out the [How to Query the API](./02-query-the-api/01-how-to-query-the-api.md) page.
 
 ### Pagination of API Results
 
-When querying a Prismic repository, your results will be paginated. By default, there are 20 documents per page in the results. You can read more about how to manipulate the pagination in the [Pagination for Results](../02-query-the-api/16-pagination-for-results.md) page.
+When querying a Prismic repository, your results will be paginated. By default, there are 20 documents per page in the results. You can read more about how to manipulate the pagination in the [Pagination for Results](./02-query-the-api/16-pagination-for-results.md) page.
 
 ## 5. Add the queried content to your templates
 
@@ -75,7 +75,7 @@ You can read more about templating your content in the Templating section of the
 
 ## 6. Take advantage of Previews and the Prismic Toolbar
 
-In order to take full advantage of Prismic's features, check out the[ Previews and the Prismic Toolbar](../04-beyond-the-api/02-previews-and-the-toolbar.md) page. There you will find the steps needed to add these features to your own Ruby app.
+In order to take full advantage of Prismic's features, check out the[ Previews and the Prismic Toolbar](./04-beyond-the-api/02-previews-and-the-toolbar.md) page. There you will find the steps needed to add these features to your own Ruby app.
 
 ## And your Prismic journey begins!
 

--- a/docs-usage/02-query-the-api/01-how-to-query-the-api.md
+++ b/docs-usage/02-query-the-api/01-how-to-query-the-api.md
@@ -1,0 +1,73 @@
+# How to Query the API
+
+In order to retrieve the content from your repository, you will need to query the repository API and specify exactly what it is you are looking for. You could query the repository for all the documents of certain type or retrieve one specific document.
+
+Let’s take a look at how to put together queries for whatever case you need.
+
+## The Basics
+
+When retrieving content from your Prismic repository, here's what a typical query looks like:
+
+```ruby
+response = api.query(
+   Prismic::Predicates.at("document.type", "blog-post"),
+   { "orderings" => "[my.blog-post.date desc]" }
+)
+# response is the response object, response.results holds the documents
+```
+
+This is the basic format of a query. In the query you have two parts, the Predicate and the options.
+
+### Predicates
+
+In the above example we had the following predicate:
+
+```ruby
+Prismic::Predicates.at("document.type", "blog-post")
+```
+
+The predicate(s) will define which documents are retrieved from the content repository. This particular example will retrieve all of the documents of the type "blog-post".
+
+The first part, "document.type" is the **path**, or what the query will be looking for. The second part of the predicate in the above example is "blog-post" this is the value that the query is looking for.
+
+You can combine more than one predicate together to refine your query. You just need to put all your predicates into a comma-separated array like the following example:
+
+```ruby
+[ Prismic::Predicates.at("document.type", "blog-post"),
+  Prismic::Predicates.at("document.tags", ["featured"]) ]
+```
+
+This particular query will retrieve all the documents of the "blog-post" type that also have the tag "featured".
+
+### Options
+
+In the second part of the query, you can include the options needed for that query. In the above example we had the following options
+
+```ruby
+{ "orderings" => "[my.blog-post.date desc]" }
+```
+
+This specifies how the returned list of documents will be ordered. You can include more than one option, by comma separating them as shown below:
+
+```ruby
+{ "pageSize" => 10, "page" => 2 }
+```
+
+You will find a list and description of all the available options on the [Query Options Reference](../02-query-the-api/03-query-options-reference.md) page.
+
+> **Pagination of API Results**
+>
+> When querying a Prismic repository, your results will be paginated. By default, there are 20 documents per page in the results. You can read more about how to manipulate the pagination in the [Pagination for Results](../02-query-the-api/16-pagination-for-results.md) page.
+
+Here's another example of a more advanced query with multiple predicates and multiple options:
+
+```ruby
+response = api.query(
+    [ Prismic::Predicates.at("document.type", "blog-post"),
+      Prismic::Predicates.at("document.tags", ["featured"]) ],
+    { "pageSize" => 10, "page" => 1, "orderings" => "[my.blog-post.date desc]" }
+)
+# response is the response object, response.results holds the documents
+```
+
+Whenever you query your content, you end up with the response object stored in the defined variable.

--- a/docs-usage/02-query-the-api/02-date-and-time-based-predicate-reference.md
+++ b/docs-usage/02-query-the-api/02-date-and-time-based-predicate-reference.md
@@ -1,0 +1,465 @@
+# Date & Time based Predicate Reference
+
+This page describes and gives examples for all the date and time based predicates you can use when creating queries with the prismic.io Ruby development kit.
+
+All of these predicates will work when used with either the Date or Timestamp fields, as well as the first and last publication dates.
+
+Note that when using any of these predicates with either a Date or Timestamp field, you will limit the results of the query to the specified custom type.
+
+## date_after
+
+The `date_after` predicate checks that the value in the path is after the date value passed into the predicate.
+
+This will not include anything with a date equal to the input value.
+
+```css
+Prismic::Predicates.date_after( path, date )
+```
+
+| Property                                                    | Description                                                                                                |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code>       | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>date</strong><br/><code>accepted date values</code> | <p>Date object: Date.new(YYYY, MM, DD)</p><p>String in the following format: &quot;YYYY-MM-DD&quot;</p>    |
+
+Examples:
+
+```ruby
+Prismic::Predicates.date_after("document.first_publication_date", Date.new(2017, 5, 18))
+Prismic::Predicates.date_after("document.last_publication_date", "2016-07-22")
+Prismic::Predicates.date_after("my.article.release-date", "2017-01-23")
+```
+
+## date_before
+
+The `date_before` predicate checks that the value in the path is before the date value passed into the predicate.
+
+This will not include anything with a date equal to the input value.
+
+```css
+Prismic::Predicates.date_before( path, date )
+```
+
+| Property                                                    | Description                                                                                                |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code>       | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>date</strong><br/><code>accepted date values</code> | <p>Date object: Date.new(YYYY, MM, DD)</p><p>String in the following format: &quot;YYYY-MM-DD&quot;</p>    |
+
+Examples:
+
+```ruby
+Prismic::Predicates.date_before("document.first_publication_date", "2016-09-19")
+Prismic::Predicates.date_before("document.last_publication_date", Date.new(2016, 10, 15))
+Prismic::Predicates.date_before("my.post.date", Date.new(2016, 08, 24))
+```
+
+## date_between
+
+The `date_between` predicate checks that the value in the path is within the date values passed into the predicate.
+
+```css
+Prismic::Predicates.date_between( path, start_date, end_date )
+```
+
+| Property                                                          | Description                                                                                                |
+| ----------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code>             | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>start_date</strong><br/><code>accepted date values</code> | <p>Date object: Date.new(YYYY, MM, DD)</p><p>String in the following format: &quot;YYYY-MM-DD&quot;</p>    |
+| <strong>end_date</strong><br/><code>accepted date values</code>   | <p>Date object: Date.new(YYYY, MM, DD)</p><p>String in the following format: &quot;YYYY-MM-DD&quot;</p>    |
+
+Examples:
+
+```ruby
+Prismic::Predicates.date_between("document.first_publication_date", "2017-01-16", "2017-02-16")
+Prismic::Predicates.date_between("document.last_publication_date", Date.new(2017, 01, 16), Date.new(2017, 02, 16))
+Prismic::Predicates.date_between("my.blog-post.post-date", "2016-06-01", "2016-06-30")
+```
+
+## day_of_month
+
+The `day_of_month` predicate checks that the value in the path is equal to the day of the month passed into the predicate.
+
+```css
+Prismic::Predicates.day_of_month( path, day )
+```
+
+| Property                                              | Description                                                                                                |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>day</strong><br/><code>integer</code>         | <p>Day of the month</p>                                                                                    |
+
+Examples:
+
+```ruby
+Prismic::Predicates.day_of_month("document.first_publication_date", 22)
+Prismic::Predicates.day_of_month("document.last_publication_date", 30)
+Prismic::Predicates.day_of_month("my.post.date", 14)
+```
+
+## day_of_month_after
+
+The `day_of_month_after` predicate checks that the value in the path is after the day of the month passed into the predicate.
+
+> Note that this will return only the days after the specified day of the month. It will not return any documents where the day is equal to the specified day.
+
+```css
+Prismic::Predicates.day_of_month_after( path, day )
+```
+
+| Property                                              | Description                                                                                                |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>day</strong><br/><code>integer</code>         | <p>Day of the month</p>                                                                                    |
+
+Examples:
+
+```ruby
+Prismic::Predicates.day_of_month_after("document.first_publication_date", 10)
+Prismic::Predicates.day_of_month_after("document.last_publication_date", 15)
+Prismic::Predicates.day_of_month_after("my.event.date-and-time", 21)
+```
+
+## day_of_month_before
+
+The `day_of_month_before` predicate checks that the value in the path is before the day of the month passed into the predicate.
+
+> Note that this will return only the days before the specified day of the month. It will not return any documents where the date is equal to the specified day.
+
+```css
+Prismic::Predicates.day_of_month_before( path, day )
+```
+
+| Property                                              | Description                                                                                                |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>day</strong><br/><code>integer</code>         | <p>Day of the month</p>                                                                                    |
+
+Examples:
+
+```ruby
+Prismic::Predicates.day_of_month_before("document.first_publication_date", 15)
+Prismic::Predicates.day_of_month_before("document.last_publication_date", 10)
+Prismic::Predicates.day_of_month_before("my.blog-post.release-date", 23)
+```
+
+## day_of_week
+
+The `day_of_week` predicate checks that the value in the path is equal to the day of the week passed into the predicate.
+
+```css
+Prismic::Predicates.day_of_week( path, week_day )
+```
+
+| Property                                                       | Description                                                                                                |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code>          | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>week_day</strong><br/><code>string\* or integer</code> | <pre>&quot;monday&quot;, &quot;mon&quot;, or 1                                                             |
+
+&quot;tuesday&quot;, &quot;tue&quot;, or 2
+&quot;wednesday&quot;, &quot;wed&quot;, or 3
+&quot;thursday&quot;, &quot;thu&quot;, or 4
+&quot;friday&quot;, &quot;fri&quot;, or 5
+&quot;saturday&quot;, &quot;sat&quot;, or 6
+&quot;sunday&quot;, &quot;sun&quot;, or 7</pre>|
+
+For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "Monday", "monday", and "MONDAY" are all accepted values.
+
+Examples:
+
+```ruby
+Prismic::Predicates.day_of_week("document.first_publication_date", 1)
+Prismic::Predicates.day_of_week("document.last_publication_date", "sunday")
+Prismic::Predicates.day_of_week("my.concert.show-date", "Fri")
+```
+
+## day_of_week_after
+
+The `day_of_week_after` predicate checks that the value in the path is after the day of the week passed into the predicate.
+
+This predicate uses Monday as the beginning of the week:
+
+1. Monday
+1. Tuesday
+1. Wednesday
+1. Thursday
+1. Friday
+1. Saturday
+1. Sunday
+
+> Note that this will return only the days after the specified day of the week. It will not return any documents where the day is equal to the specified day.
+
+```css
+Prismic::Predicates.day_of_week_after( path, week_day )
+```
+
+| Property                                                       | Description                                                                                                |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code>          | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>week_day</strong><br/><code>string\* or integer</code> | <pre>&quot;monday&quot;, &quot;mon&quot;, or 1                                                             |
+
+&quot;tuesday&quot;, &quot;tue&quot;, or 2
+&quot;wednesday&quot;, &quot;wed&quot;, or 3
+&quot;thursday&quot;, &quot;thu&quot;, or 4
+&quot;friday&quot;, &quot;fri&quot;, or 5
+&quot;saturday&quot;, &quot;sat&quot;, or 6
+&quot;sunday&quot;, &quot;sun&quot;, or 7</pre>|
+
+For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "Monday", "monday", and "MONDAY" are all accepted values.
+
+Examples:
+
+```ruby
+Prismic::Predicates.day_of_week_after("document.first_publication_date", "friday")
+Prismic::Predicates.day_of_week_after("document.last_publication_date", "THU")
+Prismic::Predicates.day_of_week_after("my.blog-post.date", 2)
+```
+
+## day_of_week_before
+
+The `day_of_week_before` predicate checks that the value in the path is before the day of the week passed into the predicate.
+
+This predicate uses Monday as the beginning of the week:
+
+1. Monday
+1. Tuesday
+1. Wednesday
+1. Thursday
+1. Friday
+1. Saturday
+1. Sunday
+
+> Note that this will return only the days before the specified day of the week. It will not return any documents where the day is equal to the specified day.
+
+```css
+Prismic::Predicates.day_of_week_before( path, week_day )
+```
+
+| Property                                                       | Description                                                                                                |
+| -------------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code>          | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>week_day</strong><br/><code>string\* or integer</code> | <pre>&quot;monday&quot;, &quot;mon&quot;, or 1                                                             |
+
+&quot;tuesday&quot;, &quot;tue&quot;, or 2
+&quot;wednesday&quot;, &quot;wed&quot;, or 3
+&quot;thursday&quot;, &quot;thu&quot;, or 4
+&quot;friday&quot;, &quot;fri&quot;, or 5
+&quot;saturday&quot;, &quot;sat&quot;, or 6
+&quot;sunday&quot;, &quot;sun&quot;, or 7</pre>|
+
+For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "Monday", "monday", and "MONDAY" are all accepted values.
+
+Examples:
+
+```ruby
+Prismic::Predicates.day_of_week_before("document.first_publication_date", "Wed")
+Prismic::Predicates.day_of_week_before("document.last_publication_date", 6)
+Prismic::Predicates.day_of_week_before("my.page.release-date", "saturday")
+```
+
+## month
+
+The `month` predicate checks that the value in the path occurs in the month value passed into the predicate.
+
+```css
+Prismic::Predicates.month( path, month )
+```
+
+| Property                                                    | Description                                                                                                |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code>       | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>month</strong><br/><code>string\* or integer</code> | <pre>&quot;january&quot;, &quot;jan&quot;, or 1                                                            |
+
+&quot;february&quot;, &quot;feb&quot;, or 2
+&quot;march&quot;, &quot;mar&quot;, or 3
+&quot;april&quot;, &quot;apr&quot;, or 4
+&quot;may&quot; or 5
+&quot;june&quot;, &quot;jun&quot;, or 6
+&quot;july&quot;, &quot;jul&quot;, or 7
+&quot;august&quot;, &quot;aug&quot;, or 8
+&quot;september&quot;, &quot;sep&quot;, or 9
+&quot;october&quot;, &quot;oct&quot;, or 10
+&quot;november&quot;, &quot;nov&quot;, or 11
+&quot;december&quot;, &quot;dec&quot;, or 12</pre>|
+
+For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "January", "january", and "JANUARY" are all accepted values.
+
+Examples:
+
+```ruby
+Prismic::Predicates.month("document.first_publication_date", "august")
+Prismic::Predicates.month("document.last_publication_date", "Sep")
+Prismic::Predicates.month("my.blog-post.date", 1)
+```
+
+## month_after
+
+The `month_after` predicate checks that the value in the path occurs in any month after the value passed into the predicate.
+
+> Note that this will only return documents where the date is after the specified month. It will not return any documents where the date is within the specified month.
+
+```css
+Prismic::Predicates.month_after( path, month )
+```
+
+| Property                                                    | Description                                                                                                |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code>       | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>month</strong><br/><code>string\* or integer</code> | <pre>&quot;january&quot;, &quot;jan&quot;, or 1                                                            |
+
+&quot;february&quot;, &quot;feb&quot;, or 2
+&quot;march&quot;, &quot;mar&quot;, or 3
+&quot;april&quot;, &quot;apr&quot;, or 4
+&quot;may&quot; or 5
+&quot;june&quot;, &quot;jun&quot;, or 6
+&quot;july&quot;, &quot;jul&quot;, or 7
+&quot;august&quot;, &quot;aug&quot;, or 8
+&quot;september&quot;, &quot;sep&quot;, or 9
+&quot;october&quot;, &quot;oct&quot;, or 10
+&quot;november&quot;, &quot;nov&quot;, or 11
+&quot;december&quot;, &quot;dec&quot;, or 12</pre>|
+
+For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "January", "january", and "JANUARY" are all accepted values.
+
+Examples:
+
+```ruby
+Prismic::Predicates.month_after("document.first_publication_date", "February")
+Prismic::Predicates.month_after("document.last_publication_date", 6)
+Prismic::Predicates.month_after("my.article.date", "oct")
+```
+
+## month_before
+
+The `month_before` predicate checks that the value in the path occurs in any month before the value passed into the predicate.
+
+> Note that this will only return documents where the date is before the specified month. It will not return any documents where the date is within the specified month.
+
+```css
+Prismic::Predicates.month_before( path, month )
+```
+
+| Property                                                    | Description                                                                                                |
+| ----------------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code>       | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>month</strong><br/><code>string\* or integer</code> | <pre>&quot;january&quot;, &quot;jan&quot;, or 1                                                            |
+
+&quot;february&quot;, &quot;feb&quot;, or 2
+&quot;march&quot;, &quot;mar&quot;, or 3
+&quot;april&quot;, &quot;apr&quot;, or 4
+&quot;may&quot; or 5
+&quot;june&quot;, &quot;jun&quot;, or 6
+&quot;july&quot;, &quot;jul&quot;, or 7
+&quot;august&quot;, &quot;aug&quot;, or 8
+&quot;september&quot;, &quot;sep&quot;, or 9
+&quot;october&quot;, &quot;oct&quot;, or 10
+&quot;november&quot;, &quot;nov&quot;, or 11
+&quot;december&quot;, &quot;dec&quot;, or 12</pre>|
+
+For any of the string input values you can use either first letter capitalized, all lowercase, or all uppercase. For example, "January", "january", and "JANUARY" are all accepted values.
+
+Examples:
+
+```ruby
+Prismic::Predicates.month_before("document.first_publication_date", 8)
+Prismic::Predicates.month_before("document.last_publication_date", "june")
+Prismic::Predicates.month_before("my.blog-post.release-date", "Sep")
+```
+
+## year
+
+The `year` predicate checks that the value in the path occurs in the year value passed into the predicate.
+
+```css
+Prismic::Predicates.year( path, year )
+```
+
+| Property                                              | Description                                                                                                |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>year</strong><br/><code>integer</code>        | <p>Year</p>                                                                                                |
+
+Examples:
+
+```ruby
+Prismic::Predicates.year("document.first_publication_date", 2016)
+Prismic::Predicates.year("document.last_publication_date", 2017)
+Prismic::Predicates.year("my.employee.birthday", 1986)
+```
+
+## hour
+
+The `hour` predicate checks that the value in the path occurs within the hour value passed into the predicate.
+
+This uses the 24 hour system, starting at 0 and going through 23.
+
+> Note that this predicate will technically work for a Date field, but won’t be very useful. All date field values are automatically given an hour of 0.
+
+```css
+Prismic::Predicates.hour( path, hour )
+```
+
+| Property                                              | Description                                                                                                |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>hour</strong><br/><code>integer</code>        | <p>Hour between 0 and 23</p>                                                                               |
+
+Examples:
+
+```ruby
+Prismic::Predicates.hour("document.first_publication_date", 12)
+Prismic::Predicates.hour("document.last_publication_date", 8)
+Prismic::Predicates.hour("my.event.date-and-time", 19)
+```
+
+## hour_after
+
+The `hour_after` predicate checks that the value in the path occurs after the hour value passed into the predicate.
+
+This uses the 24 hour system, starting at 0 and going through 23.
+
+> Note that this will only return documents where the timestamp is after the specified hour. It will not return any documents where the timestamp is within the specified hour.
+
+> This predicate will technically work for a Date field, but won’t be very useful. All date field values are automatically given an hour of 0.
+
+```css
+Prismic::Predicates.hour_after( path, hour )
+```
+
+| Property                                              | Description                                                                                                |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>hour</strong><br/><code>integer</code>        | <p>Hour between 0 and 23</p>                                                                               |
+
+Examples:
+
+```ruby
+Prismic::Predicates.hour_after("document.first_publication_date", 21)
+Prismic::Predicates.hour_after("document.last_publication_date", 8)
+Prismic::Predicates.hour_after("my.blog-post.releaseDate", 16)
+```
+
+## hour_before
+
+The `hour_before` predicate checks that the value in the path occurs before the hour value passed into the predicate.
+
+This uses the 24 hour system, starting at 0 and going through 23.
+
+> Note that this will only return documents where the timestamp is before the specified hour. It will not return any documents where the timestamp is within the specified hour.
+
+> This predicate will technically work for a Date field, but won’t be very useful. All date field values are automatically given an hour of 0.
+
+```css
+Prismic::Predicates.hour_before( path, hour )
+```
+
+| Property                                              | Description                                                                                                |
+| ----------------------------------------------------- | ---------------------------------------------------------------------------------------------------------- |
+| <strong>path</strong><br/><code>accepted paths</code> | <p>document.first_publication_date</p><p>document.last_publication_date</p><p>my.{custom-type}.{field}</p> |
+| <strong>hour</strong><br/><code>integer</code>        | <p>Hour between 0 and 23</p>                                                                               |
+
+Examples:
+
+```ruby
+Prismic::Predicates.hour_before("document.first_publication_date", 10)
+Prismic::Predicates.hour_before("document.last_publication_date", 14)
+Prismic::Predicates.hour_before("my.event.dateAndTime", 12)
+```

--- a/docs-usage/02-query-the-api/03-query-options-reference.md
+++ b/docs-usage/02-query-the-api/03-query-options-reference.md
@@ -1,0 +1,195 @@
+# Query options reference
+
+## after
+
+The `after` option can be used along with the orderings option. It will remove all the documents except for those after the specified document in the list.
+
+To clarify, let’s say you have a query that return the following documents in this order:
+
+- ` V9Zt3icAAAl8Uzob (Page 1)`
+- `PqZtvCcAALuRUzmO (Page 2)`
+- `VkRmhykAAFA6PoBj (Page 3)`
+- `V4Fs8rDbAAH9Pfow (Page 4)`
+- `G8ZtxQhAALuSix6R (Page 5)`
+- `Ww9yuAvdAhl87wh6 (Page 6)`
+
+If you add the `after` option and specify page 3, “VkRmhykAAFA6PoBj”, your query will return the following:
+
+- `V4Fs8rDbAAH9Pfow (Page 4)`
+- `G8ZtxQhAALuSix6R (Page 5)`
+- `Ww9yuAvdAhl87wh6 (Page 6)`
+
+By reversing the orderings in your query, you can use this same method to retrieve all the documents before the specified document.
+
+This option is useful when creating a navigation for a blog.
+
+```ruby
+{ "after" => "VkRmhykAAFA6PoBj" }
+```
+
+## fetch
+
+The `fetch` option is used to make queries faster by only retrieving the specified field(s).
+
+To retrieve a single field, simply specify the field as shown below.
+
+```ruby
+{ "fetch" => "product.title" }
+```
+
+To retrieve more than one field, you just need to comma separate all the fields you wish included in the response.
+
+```ruby
+{ "fetch" => "product.title, product.price" }
+```
+
+## fetchLinks
+
+The `fetchLinks` option allows you to retrieve a specific content field from a linked document and add it to the document response object.
+
+Note that this will only retrieve content of the following field types:
+
+- Color
+- Content Relationship
+- Date
+- Image
+- Key Text
+- Number
+- Select
+- Timestamp
+- Title
+
+It is **not** possible to retrieve the following content field types:
+
+- Embed
+- GeoPoint
+- Link
+- Link to Media
+- Rich Text
+- Any field in a Group or Slice
+
+The value you enter for the fetchLinks option needs to take the following format:
+
+```ruby
+{ "fetchLinks" => "{custom-type}.{field}" }
+```
+
+| Property                            | Description                                                                  |
+| ----------------------------------- | ---------------------------------------------------------------------------- |
+| <strong>{custom-type}</strong><br/> | <p>The custom type API-ID of the linked document</p>                         |
+| <strong>{field}</strong><br/>       | <p>The API-ID of the field you wish to retrieve from the linked document</p> |
+
+To view a complete example of how this option works, check out the [Fetch Linked Document Fields](../02-query-the-api/14-fetch-linked-items.md) page.
+
+Examples:
+
+```ruby
+{ "fetchLinks" => "author.full_name" }
+{ "fetchLinks" => "author.first-name, author.last-name" }
+```
+
+## lang
+
+The `lang` option defines the language code for the results of your query.
+
+### Specify a particular language/region
+
+You can use the *lang* option to specify a particular language/region you wish to query by. You just need to set the lang value to the desired language code, for example "en-us" for American English.
+
+If no *lang* option is provided, then the query will default to the master language of the repository.
+
+```ruby
+{ "lang" => "en-us" }
+```
+
+### Query all languages
+
+You can also use the *lang* option to specify that you want to query documents in all available languages. Simply set the *lang* option to the wildcard value `*`.
+
+```ruby
+{ "lang" => "*" }
+```
+
+To view a complete example of how this option works, view the examples on the [Query by Language](../02-query-the-api/17-query-by-language.md) page.
+
+## orderings
+
+The `orderings` option orders the results by the specified field(s). You can specify as many fields as you want.
+
+| Property                                | Description                                                                                    |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| <strong>lowest to highest</strong><br/> | <p>It will automatically order the field from lowest to highest</p>                            |
+| <strong>highest to lowest</strong><br/> | <p>Use &quot;desc&quot; next to the field name to instead order it from greatest to lowest</p> |
+
+```ruby
+{ "orderings" => "[my.product.price]" } # lowest to highest
+{ "orderings" => "[my.product.price desc]" } # highest to lowest
+```
+
+### Multiple orderings
+
+You can specify more than one field to order your results by. To do so, simply add more than one field in the array.
+
+The results will be ordered by the first field in the array. If any of the results have the same value for that initial sort, they will then be sorted by the next specified field. And so on.
+
+Here is an example that first sorts the products by price from lowest to highest. If any of the products have the same price, then they will be sorted by their titles.
+
+```ruby
+{ "orderings" => "[my.product.price, my.product.title]" }
+```
+
+### Sort by publication date
+
+It is also possible to order documents by their first or last publication dates.
+
+| Property                                     | Description                                                                    |
+| -------------------------------------------- | ------------------------------------------------------------------------------ |
+| <strong>first_publication_date</strong><br/> | <p>The date that the document was originally published for the first time</p>  |
+| <strong>last_publication_date</strong><br/>  | <p>The most recent date that the document has been published after editing</p> |
+
+```ruby
+{ "orderings" => "[document.first_publication_date]" }
+{ "orderings" => "[document.last_publication_date]" }
+```
+
+## page
+
+The `page` option defines the pagination for the result of your query.
+
+If unspecified, the pagination will default to "1", corresponding to the first page.
+
+| Property                                        | Description                                         |
+| ----------------------------------------------- | --------------------------------------------------- |
+| <strong>value</strong><br/><code>integer</code> | <p>page index (1 = 1st page, 2 = 2nd page, ...)</p> |
+
+```ruby
+{ "page" => 2 }
+```
+
+## pageSize
+
+The `pageSize` option defines the maximum number of documents that the API will return for your query.
+
+If left unspecified, the page size will default to 20. The maximum page size is 100.
+
+| Property                                        | Description                          |
+| ----------------------------------------------- | ------------------------------------ |
+| <strong>value</strong><br/><code>integer</code> | <p>page size (between 1 and 100)</p> |
+
+```ruby
+{ "pageSize" => 100 }
+```
+
+## ref
+
+The `ref` option defines which version of your content to query.
+
+By default the Prismic Ruby development kit will use the master ref to retrieve the currently published documents.
+
+| Property                                       | Description                                        |
+| ---------------------------------------------- | -------------------------------------------------- |
+| <strong>value</strong><br/><code>string</code> | <p>Master, Release, Experiment, or Preview ref</p> |
+
+```ruby
+{ "ref" => "Wst7PCgAAHUAvviX" }
+```

--- a/docs-usage/02-query-the-api/04-quick-query-helper-functions.md
+++ b/docs-usage/02-query-the-api/04-quick-query-helper-functions.md
@@ -1,0 +1,118 @@
+# Quick Query Helper functions
+
+We've included helper functions to make creating certain queries quicker and easier when using the Prismic Ruby development kit. This page provides the description and examples for each of the helper functions.
+
+## getByUID
+
+The `getByUID` function is used to query the specified custom type by a certain UID. This requires that the custom type of the document contains the UID field.
+
+This function will only ever retrieve one document as there can only be one instance of a given UID value for each custom type & language.
+
+```ruby
+getByUID( custom_type, uid, options )
+```
+
+| Property                                             | Description                                                           |
+| ---------------------------------------------------- | --------------------------------------------------------------------- |
+| <strong>custom_type</strong><br/><code>string</code> | <p>(required) The API-ID of the custom type you are searching for</p> |
+| <strong>uid</strong><br/><code>string</code>         | <p>(required) The UID of the document you want to retrieve</p>        |
+| <strong>options</strong><br/><code>array</code>      | <p>(optional) An array with option parameters and values</p>          |
+
+Here is an example that queries a document of the type "page" by its uid "about-us".
+
+```ruby
+document = api.getByUID("page", "about-us")
+# document contains the document content
+```
+
+Here is an example with options that specifies a particular language to query.
+
+```ruby
+options = { "lang" => "en-us" }
+document = api.getByUID("page", "about-us", options)
+# document contains the document content
+```
+
+## getByID
+
+The `getByID` function is used to query a certain document by its id. Every document is automatically assigned a unique id when it is created. The id will look something like this: "WAjgAygABN3B0a-a".
+
+This function will only ever retrieve one document as each document has a unique id value.
+
+```ruby
+getByID( id, options )
+```
+
+| Property                                        | Description                                                   |
+| ----------------------------------------------- | ------------------------------------------------------------- |
+| <strong>id</strong><br/><code>string</code>     | <p>(required) The id of the document you want to retrieve</p> |
+| <strong>options</strong><br/><code>array</code> | <p>(optional) An array with option parameters and values</p>  |
+
+Here is an example that queries a document by its id "WAjgAygABN3B0a-a".
+
+```ruby
+document = api.getByID("WAjgAygABN3B0a-a")
+# document contains the document content
+```
+
+Here is an example with options.
+
+```ruby
+options = { "fetch" => "product.title" }
+document = api.getByID("WAjgAygABN3B0a-a", options)
+# document contains the document content
+```
+
+## getByIDs
+
+The `getByIDs` function is used to query multiple documents by their ids.
+
+This will return the documents in the same order specified in the array, unless options are added to sort them otherwise.
+
+```ruby
+getByIDs( ids, options )
+```
+
+| Property                                        | Description                                                                              |
+| ----------------------------------------------- | ---------------------------------------------------------------------------------------- |
+| <strong>ids</strong><br/><code>array</code>     | <p>(required) An array of strings with the ids of the documents you want to retrieve</p> |
+| <strong>options</strong><br/><code>array</code> | <p>(optional) An array with option parameters and values</p>                             |
+
+Here is an example that queries multiple documents by their ids.
+
+```ruby
+ids = [ "WAjgAygAAN3B0a-a", "WC7GECUAAHBHQd-Y", "WEE_gikAAC2feA-z" ]
+response = api.getByIDs(ids)
+# response is the response object, response.results holds the documents
+```
+
+Here is an example with options that sort the documents by their titles.
+
+```ruby
+ids = [ "WAjgAygAAN3B0a-a", "WC7GECUAAHBHQd-Y", "WEE_gikAAC2feA-z" ]
+options = { "orderings" => "[my.page.title]" }
+response = api.getByIDs(ids, options)
+# response is the response object, response.results holds the documents
+```
+
+## getSingle
+
+The `getSingle` function is used to query the document of a Single custom type. Single custom types only allow for the creation of one document of that type.
+
+This will only ever retrieve one document.
+
+```ruby
+getSingle( custom_type, options )
+```
+
+| Property                                             | Description                                                                 |
+| ---------------------------------------------------- | --------------------------------------------------------------------------- |
+| <strong>custom_type</strong><br/><code>string</code> | <p>(required) The API ID of the single custom type you want to retrieve</p> |
+| <strong>options</strong><br/><code>array</code>      | <p>(optional) An array with option parameters and values</p>                |
+
+Here is an example that retrieves the document of the Single type "navigation".
+
+```ruby
+document = api.getSingle("navigation")
+# document contains the document content
+```

--- a/docs-usage/02-query-the-api/05-query-single-type.md
+++ b/docs-usage/02-query-the-api/05-query-single-type.md
@@ -1,0 +1,27 @@
+# Query a Single type document
+
+Here we discuss how to retrieve the content for a Single type document.
+
+## getSingle helper function
+
+In this example we are querying for the single instance of the custom type "navigation". We will do so by using the `getSingle` query helper function available in the Ruby development kit.
+
+```ruby
+document = api.getSingle("navigation")
+# document contains the document content
+```
+
+## Without the helper
+
+You can perform the same query without using the helper function. Here we again query the single document of the type "navigation".
+
+```ruby
+response = api.query(Prismic::Predicates.at("document.type", "navigation"))
+# response.results[0] contains the document content
+```
+
+> **Querying by language**
+>
+> Note that if you are trying to query a document that isn't in the master language of your repository this way, you will need to specify the language code or wildcard language value. You can read how to do this on the [Query by Language page](../02-query-the-api/17-query-by-language.md).
+>
+> If you are using the query helper function above, you do not need to do this.

--- a/docs-usage/02-query-the-api/06-query-by-id-or-uid.md
+++ b/docs-usage/02-query-the-api/06-query-by-id-or-uid.md
@@ -1,0 +1,103 @@
+# Query documents by ID or UID
+
+You can retrieve either multiple documents or a single one by their document ID or UID.
+
+> **Querying by language**
+>
+> Note that if you are trying to query a document that isn't in the master language of your repository, you will need to specify the language code or wildcard language value. You can read how to do this on the [Query by Language page](../02-query-the-api/17-query-by-language.md).
+>
+> If you are using one of the query helper functions below, you do not need to do this. The only exception is the `getByUID` helper which is explained below.
+
+## Query a document by ID
+
+We've created a helper function that makes it easy to query by ID, but it is also possible to do this without the helper function.
+
+### getByID helper function
+
+Here is an example that shows how to query a document by its ID using the `getByID` helper function.
+
+```ruby
+document = api.getByID("WAjgAygABN3B0a-a")
+# document contains the document content
+```
+
+### Without the helper function
+
+Here we perform the same query for a document by its ID without using the helper function.
+
+```ruby
+response = api.query(
+    Prismic::Predicates.at("document.id", "WAjgAygAAN3B0a-a"),
+    { "lang" => "*" }
+)
+document = response.results[0]
+# document contains the document content
+```
+
+## Query multiple documents by IDs
+
+We've created a helper function that makes it easy to query multiple documents by IDs.
+
+### getByIDs helper function
+
+Here is an example of querying multiple documents by their ids using the `getByIDs` helper function.
+
+```ruby
+ids = [ "WAjgAygAAN3B0a-a", "WC7GECUAAHBHQd-Y", "WEE_gikAAC2feA-z" ]
+response = api.getByIDs(ids)
+# response is the response object, response.results holds the documents
+```
+
+### Without the helper function
+
+Here is an example of how to perform the same query as above, but this time without using the helper function.
+
+```ruby
+ids = [ "WAjgAygAAN3B0a-a", "WC7GECUAAHBHQd-Y", "WEE_gikAAC2feA-z" ]
+response = api.query(
+    Prismic::Predicates.in("document.id", ids),
+    { "lang" => "*" }
+)
+# response is the response object, response.results holds the documents
+```
+
+## Query a document by its UID
+
+If you have added the UID field to a custom type, you can query a document by its UID.
+
+### getByUID helper function
+
+Here is an example showing how to query a document of the type "page" by its UID "about-us" using the `getByUID` helper function.
+
+```ruby
+document = api.getByUID("page", "about-us")
+# document contains the document content
+```
+
+### Query by language
+
+It's possible that you may have documents in different languages with the same UID value. In that case, you will need to specify the language code in order to retrieve the correct document.
+
+```ruby
+options = { "lang" => "fr-fr" }
+document = api.getByUID("page", "about-us", options)
+# document contains the document content
+```
+
+> Note that if you don't specify the language or if you specify the wildcard value `"*"`, the oldest document with this UID value will be returned.
+
+### Query all language versions by UID
+
+The `getByUID` function will always return a single document. If you need to query all the language versions that share the same UID, then you can use the following method (without the helper function) to retrieve them all at the same time.
+
+### Without the helper function
+
+Here is an example of the same query without using the helper function. It will query the document(s) of the type "page" that contains the UID "about us".
+
+```ruby
+response = api.query(
+    Prismic::Predicates.at("my.page.uid", "about-us"),
+    { "lang" => "*" }
+)
+# response.results[0] contains the document content
+```

--- a/docs-usage/02-query-the-api/07-query-all-documents.md
+++ b/docs-usage/02-query-the-api/07-query-all-documents.md
@@ -1,0 +1,24 @@
+# Query all your documents
+
+This page shows you how to query all the documents in your prismic.io content repository.
+
+## Without query options
+
+Here is an example that will query your repository for all documents using the `all` function.
+
+By default, the API will paginate the results, with 20 documents per page.
+
+```ruby
+response = api.all()
+# response is the response object, response.results holds the documents
+```
+
+## With query options
+
+You can add options to this query. In the following example we allow 100 documents per page for the query response.
+
+```ruby
+options = { "pageSize" => 100 }
+response = api.all(options)
+# response is the response object, response.results holds the documents
+```

--- a/docs-usage/02-query-the-api/08-query-by-type.md
+++ b/docs-usage/02-query-the-api/08-query-by-type.md
@@ -1,0 +1,40 @@
+# Query by Type
+
+Here we discuss how to query all the documents of a certain custom type from your content repository.
+
+## By One Type
+
+### Example 1
+
+This first example shows how to query all of the documents of the custom type "blog-post". The option included in this query will sort the results by their "date" field (from most recent to the oldest).
+
+```ruby
+response = api.query(
+    Prismic::Predicates.at("document.type", "blog-post"),
+    { "orderings" => "[my.blog-post.date desc]" }
+)
+# response is the response object, response.results holds the documents
+```
+
+### Example 2
+
+The following example shows how to query all of the documents of the custom type "video-game". The options will make it so that the results are sorted alphabetically, limited to 10 games per page, and showing the second page of results.
+
+```ruby
+response = api.query(
+    Prismic::Predicates.at("document.type", "video-game"),
+    { "pageSize" => 10, "page" => 2, "orderings" => "[my.video-game.title]" }
+)
+# response is the response object, response.results holds the documents
+```
+
+## By Multiple Types
+
+This example shows how to query all of the documents of two different custom types: "article" and "blog_post".
+
+```ruby
+response = api.query(
+  Prismic::Predicates.any("document.type", ["article", "blog_post"])
+)
+# response is the response object, response.results holds the documents
+```

--- a/docs-usage/02-query-the-api/09-query-by-tag.md
+++ b/docs-usage/02-query-the-api/09-query-by-tag.md
@@ -1,0 +1,25 @@
+# Query by Tag
+
+Here we show how to query all of the documents with a certain tag.
+
+## Query a single tag
+
+This example shows how to query all the documents with the tag "English".
+
+```ruby
+response = api.query(
+    Prismic::Predicates.at("document.tags", ["English"])
+)
+# response is the response object, response.results holds the documents
+```
+
+## Query multiple tags
+
+The following example shows how to query all of the documents with either the tag "Tag 1" or "Tag 2".
+
+```ruby
+response = api.query(
+    Prismic::Predicates.any("document.tags", ["Tag 1", "Tag 2"])
+)
+# response is the response object, response.results holds the documents
+```

--- a/docs-usage/02-query-the-api/10-query-by-date.md
+++ b/docs-usage/02-query-the-api/10-query-by-date.md
@@ -1,0 +1,46 @@
+# Query by Date
+
+This page shows multiple ways to query documents based on a date field.
+
+Here we use a few predicates that can query based on Date or Timestamp fields. Feel free to explore the[ Date & Time based Predicate Reference](../02-query-the-api/02-date-and-time-based-predicate-reference.md) page to learn more about this.
+
+## Query by an exact date
+
+The following is an example that shows how to query for all the documents of the type "article" with the release-date field ("date") equal to October 22, 2020.
+
+> Note that this type of query will only work for the Date Field, not the Time Stamp field.
+
+```ruby
+date = Date.new(2017, 1, 22)
+response = api.query(
+    Prismic::Predicates.at("my.article.release-date", date.strftime())
+)
+# response is the response object, response.results holds the documents
+```
+
+## Query by month and year
+
+Here is an example of a query for all documents of the type "blog-post" whose release-date is in the month of May in the year 2019. This might be useful for a blog archive.
+
+```ruby
+response = api.query([
+    Prismic::Predicates.month("my.blog-post.release-date", "May"),
+    Prismic::Predicates.year("my.blog-post.release-date", 2019)
+])
+# response is the response object, response.results holds the documents
+```
+
+## Query by publication date
+
+You can also query documents by their first or last publication dates.
+
+Here is an example of a query for all documents of the type "blog-post" whose original publication date is in the month of January in the year 2019.
+
+```ruby
+response = api.query([
+   Prismic::Predicates.at("document.type", "blog-post"),
+   Prismic::Predicates.month("document.first_publication_date", "january"),
+   Prismic::Predicates.year("document.first_publication_date", 2017)
+])
+# response is the response object, response.results holds the documents
+```

--- a/docs-usage/02-query-the-api/11-query-by-content-relationship.md
+++ b/docs-usage/02-query-the-api/11-query-by-content-relationship.md
@@ -1,0 +1,33 @@
+# Query by Content Relationship
+
+To query by a particular Content Relationship / Document link value, you must use the ID of the document you are looking for.
+
+> **You must use the document ID**
+>
+> Note that you must use the document ID to make this query. It does not work if you try to query using a UID value.
+
+## By a Content Relationship field
+
+The following example queries all the "blog_post" custom type documents with the "category_link" field (a Content Relationship) equal to the category document with the ID of "WNje3SUAAEGBu8bc".
+
+```ruby
+response = api.query([
+    Prismic::Predicates.at("document.type", "blog_post"),
+    Prismic::Predicates.at("my.blog_post.category_link", "WNje3SUAAEGBu8bc")]
+)
+# response contains the response object, response.results holds the documents
+```
+
+## By a Content Relationship field in a Group
+
+If your Content Relationship field is inside a group, you just need to specify the Group, then the Content Relationship field.
+
+Here is an example that queries all the "blog_post" custom type documents with the "category_link" field (a Content Relationship) equal to the category with a document ID of "WNje3SUAAEGBu8bc". In this case, the Content Relationship field is inside a Group field with the API ID of "categories".
+
+```ruby
+response = api.query([
+    Prismic::Predicates.at("document.type", "blog_post"),
+    Prismic::Predicates.at("my.blog_post.categories.category_link", "WNje3SUAAEGBu8bc")]
+)
+# response contains the response object, response.results holds the documents
+```

--- a/docs-usage/02-query-the-api/12-fulltext-search.md
+++ b/docs-usage/02-query-the-api/12-fulltext-search.md
@@ -1,0 +1,25 @@
+# Fulltext search
+
+You can use the Fulltext predicate to search a document for a given term or terms.
+
+The `Fulltext` predicate searches the term in any of the following fields:
+
+- Rich Text
+- Title
+- Key Text
+- UID
+- Select
+
+> Note that the fulltext search is not case sensitive.
+
+## Example Query
+
+This example shows how to query for all the documents of the custom type "blog-post" that contain the word "prismic".
+
+```ruby
+response = api.query([
+    Prismic::Predicates.at("document.type", "blog-post"),
+    Prismic::Predicates.fulltext("document", "prismic")]
+)
+# response contains the response object, response.results holds the documents
+```

--- a/docs-usage/02-query-the-api/13-use-multiple-predicates.md
+++ b/docs-usage/02-query-the-api/13-use-multiple-predicates.md
@@ -1,0 +1,29 @@
+# Use multiple Predicates
+
+You can combine multiple predicates in a single query, for example querying for a certain custom type with a given tag.
+
+You simply need to put all the predicates into a comma-separated array.
+
+## Example 1
+
+Here is an example that queries all of the documents of the custom type "blog-post" that have the tag "featured".
+
+```ruby
+response = api.query([
+    Prismic::Predicates.at("document.type", "blog-post"),
+    Prismic::Predicates.at("document.tags", ["featured"])]
+)
+# response contains the response object, response.results holds the documents
+```
+
+## Example 2
+
+Here is an example that queries all of the documents of the custom type "employee" excluding those with the tag "manager".
+
+```ruby
+response = api.query([
+    Prismic::Predicates.at("document.type", "employee"),
+    Prismic::Predicates.not("document.tags", ["manager"])]
+)
+# response contains the response object, response.results holds the documents
+```

--- a/docs-usage/02-query-the-api/14-fetch-linked-items.md
+++ b/docs-usage/02-query-the-api/14-fetch-linked-items.md
@@ -1,0 +1,66 @@
+# Fetch Linked Document Fields
+
+You can use the fetchLinks option to add additional fields from a linked document to the query results.
+
+## The fetchLinks option
+
+The `fetchLinks` option allows you to retrieve a specific content field from a linked document and add it to the document response object.
+
+Note that this will only retrieve content of the following field types:
+
+- Color
+- Content Relationship
+- Date
+- Image
+- Key Text
+- Number
+- Select
+- Timestamp
+
+It is **not** possible to retrieve the following content field types:
+
+- Embed
+- GeoPoint
+- Link
+- Link to Media
+- Rich Text
+- Title
+- Any field in a Group or Slice
+
+The value you enter for the fetchLinks option needs to take the following format:
+
+```ruby
+{ "fetchLinks" => "{custom-type}.{field}" }
+```
+
+| Property                            | Description                                                                  |
+| ----------------------------------- | ---------------------------------------------------------------------------- |
+| <strong>{custom-type}</strong><br/> | <p>The custom type API-ID of the linked document</p>                         |
+| <strong>{field}</strong><br/>       | <p>The API-ID of the field you wish to retrieve from the linked document</p> |
+
+## A simple example
+
+Here is a sample query that uses the fetchLinks option.
+
+This example will query for the recipe with the uid "chocolate-chip-cookies". If the custom type "recipe" has a link to another custom type "author", then you can pull in certain fields from that linked document, in this case the "name" field.
+
+```ruby
+document = api.query(
+    Prismic::Predicates.at("my.recipe.uid", "chocolate-chip-cookies"),
+    { "fetchLinks" => "author.name" }
+).results[0]
+
+author = document["recipe.author-link"]
+# author now works like a top-level document
+
+author_name = author["author.name"].value
+# author_name contains the text from the field "name"
+```
+
+## Fetch multiple fields
+
+In order to fetch more than one field from the linked document, you just need to comma separate the desired fields. Here is an example that fetches the fields `name` and `picture` from the `author`\*\* \*\*custom type.
+
+```ruby
+{ "fetchLinks" => "author.name, author.picture" }
+```

--- a/docs-usage/02-query-the-api/15-order-your-results.md
+++ b/docs-usage/02-query-the-api/15-order-your-results.md
@@ -1,0 +1,67 @@
+# Order your results
+
+This page shows how to order the results of your query for prismic.io. It explains how to use the orderings and after predicate options.
+
+## orderings
+
+The `orderings` option orders the results by the specified field(s). You can specify as many fields as you want.
+
+| Property                                | Description                                                                                    |
+| --------------------------------------- | ---------------------------------------------------------------------------------------------- |
+| <strong>lowest to highest</strong><br/> | <p>It will automatically order the field from lowest to highest</p>                            |
+| <strong>highest to lowest</strong><br/> | <p>Use &quot;desc&quot; next to the field name to instead order it from greatest to lowest</p> |
+
+```
+{ "orderings" => "[my.product.price]" } # lowest to highest
+{ "orderings" => "[my.product.price desc]" } # highest to lowest
+```
+
+### Specifying multiple orderings
+
+You can specify more than one field to order your results by. To do so, simply add more than one field in the array.
+
+The results will be ordered by the first field in the array. If any of the results have the same value for that initial sort, they will then be sorted by the next specified field.
+
+Here is an example that first sorts the products by price from lowest to highest. If any of the products have the same price, then they will be sorted by their titles.
+
+```ruby
+{ "orderings" => "[my.product.price, my.product.title]" }
+```
+
+### Order by publication dates
+
+It is also possible to order documents by their first or last publication dates.
+
+The **first publication date** is the date that the document was originally published for the first time. The **last publication date** is the most recent date that the document has been published after editing.
+
+```ruby
+{ "orderings" => "[document.first_publication_date]" }
+{ "orderings" => "[document.last_publication_date]" }
+```
+
+## after
+
+The `after` option can be used along with the orderings option. It will remove all the documents except for those after the specified document in the list.
+
+To clarify, let’s say you have a query that return the following documents in this order:
+
+- `V9Zt3icAAAl8Uzob (Page 1)`
+- `PqZtvCcAALuRUzmO (Page 2)`
+- `VkRmhykAAFA6PoBj (Page 3)`
+- `V4Fs8rDbAAH9Pfow (Page 4)`
+- `G8ZtxQhAALuSix6R (Page 5)`
+- `Ww9yuAvdAhl87wh6 (Page 6)`
+
+If you add the after option and specify page 3, “VkRmhykAAFA6PoBj”, your query will return the following:
+
+- `V4Fs8rDbAAH9Pfow (Page 4)`
+- `G8ZtxQhAALuSix6R (Page 5)`
+- `Ww9yuAvdAhl87wh6 (Page 6)`
+
+By reversing the orderings in your query, you can use this same method to retrieve all the documents before the specified document.
+
+Simply use the `after` parameter in your query options as shown below.
+
+```ruby
+{ "after" => "VkRmhykAAFA6PoBj" }
+```

--- a/docs-usage/02-query-the-api/16-pagination-for-results.md
+++ b/docs-usage/02-query-the-api/16-pagination-for-results.md
@@ -1,0 +1,35 @@
+# Pagination for results
+
+The results retrieved from the prismic.io repository will automatically be paginated. Here you will find an explanation for how to modify the pagination parameters.
+
+## pageSize
+
+The `pageSize` option defines the maximum number of documents that the API will return for your query.
+
+If left unspecified, the pagination will default to 20. The maximum value allowed is 100.
+
+Here is an example that shows how to query all of the documents of the custom type "recipe," allowing 100 documents per page.
+
+```ruby
+response = api.query(
+   Prismic::Predicates.at("document.type", "recipe"),
+   { "pageSize" => 100 }
+)
+# response contains the response object, response.results holds the documents
+```
+
+## page
+
+The `page` option defines the pagination for the results of your query.
+
+If left unspecified, it will default to 1, which corresponds to the first page.
+
+Here is an example that show how to query all of the documents of the custom type "recipe". The options entered will limit the results to 50 recipes per page, and will display the third page of results.
+
+```ruby
+response = api.query(
+    Prismic::Predicates.at("document.type", "recipe"),
+    { "pageSize" => 50, "page" => 3 }
+)
+# response contains the response object, response.results holds the documents
+```

--- a/docs-usage/02-query-the-api/17-query-by-language.md
+++ b/docs-usage/02-query-the-api/17-query-by-language.md
@@ -1,0 +1,37 @@
+# Query by language
+
+When querying the API, you can query by language.
+
+## Query a specific language
+
+You simply need to add the `lang` query option and set it to the language code you are querying (example, "en-us" for American English).
+
+> If you don't specify a `lang` the query will automatically query the documents in your master language.
+
+Here is an example of how to query for all the documents of the type "blog-post" in French (language code "fr-fr").
+
+```ruby
+response = api.query(
+    Prismic::Predicates.at("document.type", "blog-post"),
+    { "lang" => "fr-fr" }
+)
+# response contains the response object, response.results holds the documents
+```
+
+## Query for all languages
+
+If you want to query all the document in all languages you can add the wildcard, `"*"`, as your lang option.
+
+This example shows how to query all documents of the type "blog-post" in all languages.
+
+```ruby
+response = api.query(
+    Prismic::Predicates.at("document.type", "blog-post"),
+    { "lang" => "*" }
+)
+# response contains the response object, response.results holds the documents
+```
+
+## Query by UID & language
+
+To learn more about how to query your documents by UID and language, check out the [Query by ID and UID](../02-query-the-api/06-query-by-id-or-uid.md) page.

--- a/docs-usage/03-templating/01-the-response-object.md
+++ b/docs-usage/03-templating/01-the-response-object.md
@@ -1,0 +1,97 @@
+# The response object
+
+After you set up your Custom Types and have queried your content from the API, it's time to integrate that content into your templates.
+
+First we'll go over the response object returned from the API, then we'll discuss how to access the results of the query.
+
+## The Response Object
+
+Let’s start by taking a look at the Response Object returned when querying the API. Here is a simple example of response object with one document that contains a couple of fields.
+
+```
+--- !ruby/object:Prismic::Response
+page: 1
+results_per_page: 20
+results_size: 1
+total_results_size: 1
+total_pages: 1
+next_page: nil
+prev_page: nil
+results:
+- !ruby/object:Prismic::Document
+  id: WKxlPCUAAIZ10EHU
+  uid: example-page
+  type: page
+  href: https://your-repo-name.prismic.io/api/documents/search?ref=WKxlPyUEEAdz...,
+  tags: []
+  slugs:
+  - example-page
+  first_publication_date: 2017-01-13 11:45:21.000000000 +00:00
+  last_publication_date: 2017-02-21 16:05:19.000000000 +00:00
+  lang: en-us
+  alternate_languages:
+    fr-fr: !ruby/object:Prismic::AlternateLanguage
+      id: WZcAEyoAACcA0LHi
+      uid: example-page-french
+      type: page
+      lang: fr-fr
+  fragments:
+    title: !ruby/object:Prismic::Fragments::StructuredText
+      blocks:
+      - !ruby/object:Prismic::Fragments::StructuredText::Block::Heading
+        text: Example Page
+        spans: []
+        label:
+        level: 1
+    date: !ruby/object:Prismic::Fragments::Date
+      value: 2017-01-13 00:00:00.000000000 +01:00
+```
+
+At the topmost level of the response object, you mostly have information about the number of results returned from the query and the pagination of the results.
+
+| Property                                 | Description                                                                           |
+| ---------------------------------------- | ------------------------------------------------------------------------------------- |
+| <strong>page</strong><br/>               | <p>The current page of the pagination of the results</p>                              |
+| <strong>results_per_page</strong><br/>   | <p>The number of documents per page of the pagination</p>                             |
+| <strong>results_size</strong><br/>       | <p>The number of documents on this page of the pagination results</p>                 |
+| <strong>total_results_size</strong><br/> | <p>The total number of documents returned from the query</p>                          |
+| <strong>total_pages</strong><br/>        | <p>The total number of pages in the pagination of the results</p>                     |
+| <strong>next_page</strong><br/>          | <p>The next page number in the pagination</p>                                         |
+| <strong>prev_page</strong><br/>          | <p>The previous page number in the pagination</p>                                     |
+| <strong>results</strong><br/>            | <p>The documents and their content for this page of the pagination of the results</p> |
+
+> Note that when using certain helper functions such as getSingle(), getByUID(), or getByID(), the results will automatically be returned.
+
+## The Query Results
+
+The actual content of the returned documents can be found under "results". This will always be an array of the documents, even if there is only one document returned.
+
+Let’s say that you saved your response object in a variable named "response". This would mean that your documents could be accessed with the following:
+
+```ruby
+response.results
+```
+
+And if you only returned one document, it would be accessed with the following:
+
+```ruby
+response.results[0]
+```
+
+Each document will contain information such as its document ID, UID, type, tags, slugs, first publication date, & last publication date.
+
+The content for each document will be found inside "fragments". In the example above you have `title` and `date`.
+
+## Content Field Helper Functions
+
+The Ruby development kit provided by prismic.io comes with helper functions that make it easy to retrieve the content for each content field type.
+
+These will all look something like the following.
+
+```ruby
+document["page.illustration"].url
+```
+
+In the case above, "page" is the API-ID of the Custom Type and "illustration" is the API ID of the Image field.
+
+The helper functions available for each content field are shown on their individual templating pages.

--- a/docs-usage/03-templating/02-the-document-object.md
+++ b/docs-usage/03-templating/02-the-document-object.md
@@ -1,0 +1,116 @@
+# The Document object
+
+Here we will discuss the document object for Prismic when using the Ruby development kit.
+
+> **Before Reading**
+>
+> This article assumes that you have queried your API and saved the document object in a variable named `document`.
+
+## An example response
+
+Let's start by taking a look at the Document Object returned when querying the API. Here is a simple example of a document that contains a couple of fields.
+
+```ruby
+--- !ruby/object:Prismic::Document
+id: WKxlPCUAAIZ10EHU
+uid: example-page
+type: page
+href: https://your-repo-name.prismic.io/api/documents/search?ref=WKxlPyUEEAdz...,
+tags:
+  - Tag 1
+  - Tag 2
+slugs:
+  - example-page
+first_publication_date: 2017-01-13 11:45:21.000000000 +00:00
+last_publication_date: 2017-02-21 16:05:19.000000000 +00:00
+lang: en-us
+alternate_languages:
+  fr-fr: !ruby/object:Prismic::AlternateLanguage
+    id: WZcAEyoAACcA0LHi
+    uid: example-page-french
+    type: page
+    lang: fr-fr
+fragments:
+  title: !ruby/object:Prismic::Fragments::StructuredText
+    blocks:
+      - !ruby/object:Prismic::Fragments::StructuredText::Block::Heading
+        text: Example Page
+        spans: []
+        label:
+        level: 1
+  date: !ruby/object:Prismic::Fragments::Date
+    value: 2017-01-13 00:00:00.000000000 +01:00
+```
+
+## Accessing Document Fields
+
+Here is how to access each document field.
+
+### ID
+
+```javascript
+document.id;
+```
+
+### UID
+
+```javascript
+document.uid;
+```
+
+### Type
+
+```javascript
+document.type;
+```
+
+### API Url
+
+```javascript
+document.href;
+```
+
+### Tags
+
+```javascript
+document.tags;
+// returns an array
+```
+
+### First Publication Date
+
+```javascript
+document.first_publication_date;
+```
+
+### Last Publication Date
+
+```javascript
+document.last_publication_date;
+```
+
+### Language
+
+```javascript
+document.lang;
+```
+
+### Alternate Language Versions
+
+```javascript
+document.alternate_languages;
+// returns an array
+```
+
+You can read more about this in the [Multi-language Templating](../03-templating/12-multi-language-info.md) page.
+
+## Document Content
+
+To retrieve the content fields from the document you must specify the API ID of the field. Here is an example that retrieves a Date field's content from the document. Here the Date field has the API ID of `date`.
+
+```javascript
+// Assuming the document is of the type 'page'
+document["page.date"].value;
+```
+
+Refer to the specific templating documentation for each field to learn how to add content fields to your pages.

--- a/docs-usage/03-templating/03-boolean.md
+++ b/docs-usage/03-templating/03-boolean.md
@@ -1,0 +1,5 @@
+# Templating the Boolean field
+
+The Boolean field will add a switch for a true or false values for the content authors to pick from.
+
+## We don't yet support the Boolean field for Ruby

--- a/docs-usage/03-templating/04-color.md
+++ b/docs-usage/03-templating/04-color.md
@@ -1,0 +1,30 @@
+# Templating the Color field
+
+The Color field allows content writers to select a color through a variety of color pickers as well as having the option to manually input a hex value.
+
+## Get the hex color value
+
+Here's how to get the hex value of a Color field.
+
+```css
+@document ["blog-post.color"].value
+# Outputs as: efac26;
+```
+
+### An Example
+
+Here is an example that retrieves a color value to style a blog post title.
+
+```html
+<% color = @document["blog-post.color"].value %>
+<h2 style="color:#<%= color %>">Colorful Title</h2>
+```
+
+## Get the RGB value
+
+Here is an example that converts the color to an RGB value by using the `asRGB` method.
+
+```
+@document["blog-post.color"].asRGB
+# Outputs as: {"red"=>239, "green"=>172, "blue"=>38}
+```

--- a/docs-usage/03-templating/05-date.md
+++ b/docs-usage/03-templating/05-date.md
@@ -1,0 +1,37 @@
+# Templating the Date field
+
+The Date field allows content writers to add a date that represents a calendar day.
+
+## Get the date value
+
+Here's how to get the value of a Date field.
+
+```
+@document["post.date"].value
+```
+
+## Output a simple date
+
+The first way to display the date is to use the simple format: "YYYY/MM/DD".
+
+Here's an example that shows how to do this using the `to_date` method.
+
+```
+<span class="date">
+  <%= @document["post.date"].value.to_date %>
+</span>
+# Outputs in the following format: 2016/01/23
+```
+
+## Other date formats
+
+You can control the format of the date value by using `strftime` method as shown below.
+
+```
+<span class="date">
+  <%= @document["post.date"].value.strftime("%B %d, %Y") %>
+</span>
+# Outputs in the following format: January 23, 2016
+```
+
+For more formatting options, explore the [Ruby documentation for the strftime method](https://ruby-doc.org/stdlib-2.4.1/libdoc/date/rdoc/Date.html#method-i-strftime).

--- a/docs-usage/03-templating/06-embed.md
+++ b/docs-usage/03-templating/06-embed.md
@@ -1,0 +1,59 @@
+# Templating the Embed field
+
+The Embed field will let content authors paste an oEmbed supported service resource URL (YouTube, Vimeo, Soundcloud, etc.), and add the embeded content to your website.
+
+## Display as HTML
+
+Here's an example of how to integrate the Embed field into your templates using the `as_html` method.
+
+```
+<%= @document["page.embed"].as_html.html_safe %>
+```
+
+## Get the Embed type
+
+The following shows how to retrieve the Embed type from an Embed field.
+
+```
+@document["page.embed"].embed_type
+# For example this might return: video
+```
+
+## Get the Embed provider
+
+The following shows how to retrieve the Embed provider from an Embed field.
+
+```
+@document["page.embed"].provider
+# For example, this might return: YouTube
+```
+
+## Get the Embed JSON data
+
+You can also retrieve the JSON object that contains all the information about the Embed object.
+
+The `o_embed_json` method will return the JSON data.
+
+```
+@document["page.embed"].o_embed_json
+```
+
+Here's what a typical Embed JSON object would look like.
+
+```
+{
+  "height" => 270,
+  "author_name" => "RickAstleyVEVO",
+  "thumbnail_height" => 360,
+  "thumbnail_url" => "https://i.ytimg.com/vi/dQw4w9WgXcQ/hqdefault.jpg",
+  "width" => 480,
+  "html" => "<iframe width=\"480\" height=\"270\" src=\"https://www.youtube.com/embed/dQw4w9WgXcQ?feature=oembed\" frameborder=\"0\" allowfullscreen></iframe>",
+  "author_url" => "https://www.youtube.com/user/RickAstleyVEVO",
+  "provider_name" => "YouTube", "thumbnail_width" => 480,
+  "type" => "video",
+  "version" => "1.0",
+  "provider_url" => "https://www.youtube.com/",
+  "title" => "Rick Astley - Never Gonna Give You Up",
+  "embed_url" => "https://www.youtube.com/watch?v=dQw4w9WgXcQ"
+}
+```

--- a/docs-usage/03-templating/07-geopoint.md
+++ b/docs-usage/03-templating/07-geopoint.md
@@ -1,0 +1,12 @@
+# Templating the Geopoint field
+
+The GeoPoint field is used for Geolocation coordinates. It works by adding coordinates or by pasting a Google Maps URL.
+
+## Get the latitude and longitude values
+
+Here's an example of how to retrieve the latitude the longitude values from the GeoPoint field.
+
+```
+latitude = @document["store.location"].latitude
+longitude = @document["store.location"].longitude
+```

--- a/docs-usage/03-templating/08-groups.md
+++ b/docs-usage/03-templating/08-groups.md
@@ -1,0 +1,55 @@
+# Templating the Group field
+
+The Group field is used to create a repeatable collection of fields.
+
+## Repeatable Group
+
+### Looping through the Group content
+
+Here’s how to integrate a repeatable Group field into your templates. Loop through each item in the group as shown in the following example.
+
+```
+<ul>
+  <% @document["blog-post.references"].each do |link| %>
+    <li>
+      <a href="<%= link["link"].url %>">
+        <%= link["label"].as_text %>
+      </a>
+    </li>
+  <% end %>
+</ul>
+```
+
+### Another Example
+
+Here's another example that shows how to integrate a group of images (e.g. a photo gallery) into a page.
+
+```
+<div class="photo-gallery">
+  <% @document["page.photo-gallery"].each do |image| %>
+    <div class="image-with-caption">
+      <img src="<%= image["photo"].url %>" />
+      <span class="caption">
+        <%= image["caption"].as_text %>
+      </span>
+    </li>
+  <% end %>
+</div>
+```
+
+## Non-repeatable Group
+
+Even if the group is non-repeatable, the Group field will be an array. You simply need to get the first (and only) group in the array and you can retrieve the fields in the group like any other.
+
+Here is an example showing how to integrate the fields of a non-repeatable Group into your templates.
+
+```
+<% banner = @document["page.banner_group"].get(0) %>
+<div class="banner">
+  <img src="<%= banner["banner_image"].url %>" />
+  <p><%= banner["banner_text"].as_text %></p>
+  <a href="<%= banner["link"].url(link_resolver) %>">
+    <%= banner["link_label"].as_text %>
+  </a>
+</div>
+```

--- a/docs-usage/03-templating/09-images.md
+++ b/docs-usage/03-templating/09-images.md
@@ -1,0 +1,102 @@
+# Templating the Image field
+
+The Image field allows content writers to upload an image that can be configured with size constraints and responsive image views.
+
+## Get the image url
+
+The easiest way to integrate an image is to retrieve and add the image url to an image element.
+
+The following integrates a page's illustration image field.
+
+```html
+<img src="<%= @document["page.illustration"].url %>" />
+```
+
+### Example with a caption
+
+Here's an example that integrates an illustration with a caption.
+
+```html
+<img src="<%= @document["page.illustration"].url %>" />
+<span class="image-caption"><%= @document["page.caption"].as_text %></span>
+```
+
+## Output as HTML
+
+The `as_html`  method will convert and output the Image as an HTML image element.
+
+```html
+<%= @document["page.illustration"].as_html.html_safe %>
+```
+
+## Get a responsive image view
+
+The `get_view`  method allows you to retrieve and use your responsive image views. Simply pass the name of the view into the `get_view`  method and use it like any other image fragment.
+
+Here is how to add responsive images using the HTML picture element.
+
+```html
+<% main_view = @document["page.responsive-image"] tablet_view =
+@document["page.responsive-image"].get_view("tablet") mobile_view =
+@document["page.responsive-image"].get_view("mobile") %>
+
+<picture>
+  vsource media="(max-width: 400px)", srcset="<%= mobile_view.url %>" />
+  <source media="(max-width: 900px)" , srcset="<%= tablet_view.url %>" />
+  <source srcset="<%= main_view.url %>" />
+  <image src="<%= main_view.url %>" />
+</picture>
+```
+
+## Add alt or copyright text to your image
+
+### The main image
+
+If you added an alt or copyright text value to your image, you retrieve and apply it as follows.
+
+```html
+<% image_url = @document["page.image"].url image_alt =
+@document["page.image"].alt image_copyright = @document["page.image"].copyright
+%>
+<img
+  src="<%= image_url %>"
+  alt="<%= image_alt %>"
+  copyright="<%= image_copyright %>"
+/>
+```
+
+### An image view
+
+Here's how to retrieve the alt or copyright text for a responsive image view. Note that the alt and copyright text will be the same for all views.
+
+```html
+<% mobile_view = @document["page.image"].get_view("mobile") mobile_url =
+mobile_view.url mobile_alt = mobile_view.alt mobile_copyright =
+mobile_view.copyright %>
+<img
+  src="<%= mobile_url %>"
+  alt="<%= mobile_alt %>"
+  copyright="<%= mobile_copyright %>"
+/>
+```
+
+## Get the image width & height
+
+### The main image
+
+You can retrieve the main image's width or height as shown below.
+
+```javascript
+image_width = @document["article.featured-image"].width
+image_height = @document["article.featured-image"].height
+```
+
+### An image view
+
+Here is how to retrieve the width and height for a responsive image view.
+
+```javascript
+mobile_view = @document["article.featured-image"].get_view("mobile")
+mobile_width = mobile_view.width
+mobile_height = mobile_view.height
+```

--- a/docs-usage/03-templating/10-key-text.md
+++ b/docs-usage/03-templating/10-key-text.md
@@ -1,0 +1,11 @@
+# Templating the Key Text field
+
+The Key Text field allows content writers to enter a single string.
+
+## Get the text value
+
+Here's an example that shows how to retrieve the Key Text value and output the string into your template.
+
+```html
+<h1><%= @document["blog-post.title"].as_text %></h1>
+```

--- a/docs-usage/03-templating/11-links-content-relationship.md
+++ b/docs-usage/03-templating/11-links-content-relationship.md
@@ -1,0 +1,55 @@
+# Templating Link & Content Relationship fields
+
+The Link field is used for adding links to the web, to documents in your prismic.io repository, or to files in your prismic.io media library. The Content Relationship field is a Link field specifically used to link to a Document.
+
+## Link to the Web
+
+Her's how to retrieve the url for a Link to the Web which has the API ID of `external_link`.
+
+```
+<% web_link = @document["page.external_link"] %>
+<% link_url = web_link.url(link_resolver) %>
+<% if web_link.target %>
+  <a href="<%= link_url %>" target="<%= web_link.target %>" rel="noopener">Click here</a>
+<% else %>
+  <a href="<%= link_url %>">Click here</a>
+<% end %>
+```
+
+Note that the example above uses a Link Resolver. If your link field has been set up so that it can only take a Link to the Web, then this is not needed. You only need a Link Resolver if the Link field might contain a Link to a Document. Follow this link to read more about [Link Resolving](../04-beyond-the-api/01-link-resolving.md).
+
+## Link to a Document / Content Relationship
+
+### Retrieve the url for the Document
+
+When integrating a Link to a Document in your repository, a Link Resolver is necessary as shown below.
+
+```
+<% doc_link = @document["page.document-link"].url(link_resolver) %>
+<a href="<%= doc_link %>">Go to page</a>
+```
+
+Note that the example above uses a Link Resolver. A Link Resolver is required when retrieving the url for a Link to a Document.
+
+### Retrieve other information about the Document
+
+You are also able to retrieve other information about the linked Document. Here are some examples.
+
+```
+doc_id = @document["page.document-link"].id
+doc_uid = @document["page.document-link"].uid
+doc_type = @document["page.document-link"].type
+doc_tags = @document["page.document-link"].tags
+doc_lang = @document["page.document-link"].lang
+```
+
+## Link to a Media Item
+
+The following shows how to retrieve the url for a Link to a Media Item.
+
+```
+<% media_link = @document["page.media-link"].url(link_resolver) %>
+<a href="<%= media_link %>">View Image</a>
+```
+
+> Note that the example above uses a [Link Resolver](../04-beyond-the-api/01-link-resolving.md). If your link field has been set up so that it can only link to a Media Item, then this is not needed. You only need a Link Resolver if the Link field might contain a Link to a Document.

--- a/docs-usage/03-templating/12-multi-language-info.md
+++ b/docs-usage/03-templating/12-multi-language-info.md
@@ -1,0 +1,36 @@
+# Templating Multi-language info
+
+This page shows you how to access the language code and alternate language versions of a document.
+
+## Get the document language code
+
+Here is how to access the language code of a document queried from your prismic.io repository. This might give "en-us" (American english), for example.
+
+```javascript
+document.lang;
+```
+
+## Get the alternate language versions
+
+Next we will access the information about a document's alternate language versions. You can loop through the `alternate_languages` array and access the id, uid, type, and language code of each as shown below.
+
+```
+document.alternate_languages.each do |lang, doc|
+    id = doc.id
+    uid = doc.uid
+    type = doc.type
+    doc_lang = lang
+end
+```
+
+## Get a specific language version
+
+If you need to get a specific alternate language version, pass the language code of the desired language into the `alternate_languages`\*\* \*\*array as shown below.
+
+```
+french_version = @document.alternate_languages["fr-fr"]
+id = french_version.id
+uid = french_version.uid
+type = french_version.type
+lang = french_version.lang
+```

--- a/docs-usage/03-templating/13-number.md
+++ b/docs-usage/03-templating/13-number.md
@@ -1,0 +1,30 @@
+# Templating the Number field
+
+The Number field allows content writers to enter or select a number. You can set set max and min values for the number.
+
+## Get the number value
+
+Here is an example of how to simply retrieve the value of the Number field and insert it into your template.
+
+```
+<span><%= @document["article.statistic"].value %></span>
+```
+
+## Control the number of decimal places
+
+Here we see how to control the number of decimal places to ensure that our price looks right.
+
+```
+<% price = @document["product.price"].value %>
+<h3 class="price">
+  $<%= number_with_precision( price, precision: 2 ) %>
+</h3>
+```
+
+## Convert to an integer
+
+Here we see how we can convert the number to an integer.
+
+```
+<span><%= @document["page.number"].as_int %></span>
+```

--- a/docs-usage/03-templating/14-rich-text-title.md
+++ b/docs-usage/03-templating/14-rich-text-title.md
@@ -1,0 +1,64 @@
+# Templating the Rich Text & Title fields
+
+The Rich Text field (formerly called Structured Text) is a configurable text field with formatting options. This field provides content writers with a WYSIWYG editor where they can define the text as a header or paragraph, make it bold, add links, etc. The Title field is a specific Rich Text field used for titles.
+
+## Output as HTML
+
+The basic usage of the Rich Text / Title field is to use the `as_html` method to transform the field into HTML code.
+
+The following is an example that would display the title of a blog post.
+
+```
+<%= @document["blog-post.title"].as_html(link_resolver()).html_safe %>
+```
+
+In the previous example when calling the as_html  method, you need to pass in a Link Resolver function. This is needed if your content contains any links to documents in your repository. To read more about this, check out the [Link Resolving](../04-beyond-the-api/01-link-resolving.md) page.
+
+### Example 2
+
+The following example shows how to display the Rich Text body content of a blog post.
+
+```
+<%= @document["blog-post.body"].as_html(link_resolver()).html_safe %>
+```
+
+### Changing the HTML Output
+
+You can customize the HTML output by passing an HTML serializer to the method as shown below.
+
+To read more about this, check out the [HTML Serializer](../04-beyond-the-api/03-html-serializer.md) page.
+
+The following example will edit how an image in a Rich Text field is displayed while leaving all the other elements in their default output.
+
+```
+@html_serializer = Prismic.html_serializer do |element, html|
+  if element.is_a?(Prismic::Fragments::StructuredText::Block::Image)
+    %(<img src="#{element.url}" alt="#{element.alt}" width="#{element.width}" height="#{element.height}" />)
+  else
+    nil
+  end
+end
+
+# In the template
+<%= @document['blog-post.body'].as_html(link_resolver(), @html_serializer).html_safe %>
+```
+
+## Output as plain text
+
+The `as_text`  method will convert and output the text in the Rich Text / Title field as a string.
+
+```
+<h3 class="author">
+  <%= @document["page.author"].as_text %>
+</h3>
+```
+
+## Get the first heading
+
+The `first_title`  method will find the highest and first heading block in the Rich Text field and return it as a string.
+
+Here's an example of how to integrate this.
+
+```
+<h2><%= @document["page.body"].first_title %></h2>
+```

--- a/docs-usage/03-templating/15-select.md
+++ b/docs-usage/03-templating/15-select.md
@@ -1,0 +1,13 @@
+# Templating the Select field
+
+The Select field will add a dropdown select box of choices for the content authors to pick from.
+
+## Get the Select field text value
+
+The following example shows how to retrieve the value of a Select field.
+
+```
+<p class="category">
+  <%= @document["article.category"].value %>
+</p>
+```

--- a/docs-usage/03-templating/16-slices.md
+++ b/docs-usage/03-templating/16-slices.md
@@ -1,0 +1,118 @@
+# Templating Slices
+
+The Slices field is used to define a dynamic zone for richer page layouts.
+
+## Example 1
+
+Here is a simple example that shows how to add slices to your templates. In this example, we have two slice options: a text slice and an image gallery slice.
+
+### Text slice
+
+The "text" slice is simple and only contains one field, which is non-repeatable.
+
+| Property                             | Description                                                         |
+| ------------------------------------ | ------------------------------------------------------------------- |
+| <strong>non-repeatable</strong><br/> | <p>- A Rich Text field with the API ID of &quot;rich_text&quot;</p> |
+| <strong>repeatable</strong><br/>     | <p>None</p>                                                         |
+
+### Image gallery slice
+
+The "image_gallery" slice contains both repeatable and non-repeatable fields.
+
+| Property                             | Description                                                          |
+| ------------------------------------ | -------------------------------------------------------------------- |
+| <strong>non-repeatable</strong><br/> | <p>- A Title field with the API ID of &quot;gallery_title&quot;</p>  |
+| <strong>repeatable</strong><br/>     | <p>- An Image field with the API ID of &quot;gallery_image&quot;</p> |
+
+### Integration
+
+Here is an example of how to integrate these slices into a blog post.
+
+```
+<div class="blog-content">
+  <% @document["blog_post.body"].slices.each do |slice| %>
+    <% case slice.slice_type
+       when "text" %>
+          <%= slice.non_repeat["rich_text"].as_html(link_resolver).html_safe %>
+    <% when "image_gallery" %>
+        <h2><%= slice.non_repeat["gallery_title"].as_text %></h2>
+        <% slice.repeat.each do |image| %>
+          <img src="<%= image["gallery_image"].url %>">
+        <% end %>
+    <% end %>
+  <% end %>
+</div>
+```
+
+## Example 2
+
+The following is a more advanced example that shows how to use Slices for a landing page. In this example, the Slice choices are FAQ question/answers, featured items, and text sections.
+
+### FAQ slice
+
+The "faq" slice is takes advantage of both the repeatable and non-repeatable slice sections.
+
+| Property                             | Description                                                                                                                    |
+| ------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------ |
+| <strong>non-repeatable</strong><br/> | <p>- A Title field with the API ID of &quot;faq_title&quot;</p>                                                                |
+| <strong>repeatable</strong><br/>     | <p>- A Title field with the API ID of &quot;question&quot;</p><p>- A Rich Text field with the API ID of &quot;answer&quot;</p> |
+
+### Featured Items slice
+
+The "featured_items" slice contains a repeatable set of an image, title, and summary fields.
+
+| Property                             | Description                                                                                                                                                                              |
+| ------------------------------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| <strong>non-repeatable</strong><br/> | <p>None</p>                                                                                                                                                                              |
+| <strong>repeatable</strong><br/>     | <p>- An Image field with the API ID of &quot;image&quot;</p><p>- A Title field with the API ID of &quot;title&quot;</p><p>- A Rich Text field with the API ID of &quot;summary&quot;</p> |
+
+### Text slice
+
+The "text" slice contains only a Rich Text field in the non-repeatable section.
+
+| Property                             | Description                                                         |
+| ------------------------------------ | ------------------------------------------------------------------- |
+| <strong>non-repeatable</strong><br/> | <p>- A Rich Text field with the API ID of &quot;rich_text&quot;</p> |
+| <strong>repeatable</strong><br/>     | <p>None</p>                                                         |
+
+### Integration
+
+Here is an example of how to integrate these slices into a landing page.
+
+```
+<div class="page-content">
+  <% @document["page.body"].slices.each do |slice| %>
+    <% case slice.slice_type
+
+       when "faq" %>
+          <div class="faq">
+            <%= slice.non_repeat["faq_title"].as_html(link_resolver).html_safe %>
+            <% slice.repeat.each do |faq| %>
+              <div>
+                <%= faq["question"].as_html(link_resolver).html_safe %>
+                <%= faq["answer"].as_html(link_resolver).html_safe %>
+              </div>
+            <% end %>
+          </div>
+
+      <% when "featured_items" %>
+        <div class="featured-items">
+          <% slice.repeat.each do |featured_item| %>
+            <% image_url = featured_item["image"].url %>
+            <div>
+              <img src="<%= image_url %>">
+              <%= featured_item["title"].as_html(link_resolver).html_safe %>
+              <%= featured_item["summary"].as_html(link_resolver).html_safe %>
+            </div>
+          <% end %>
+        </div>
+
+      <% when "text" %>
+        <div class="text">
+          <%= slice.non_repeat["rich_text"].as_html(link_resolver).html_safe %>
+        </div>
+
+    <% end %>
+  <% end %>
+</div>
+```

--- a/docs-usage/03-templating/17-timestamp.md
+++ b/docs-usage/03-templating/17-timestamp.md
@@ -1,0 +1,37 @@
+# Templating the Timestamp field
+
+The Timestamp field allows content writers to add a date and time.
+
+## Get the Timestamp value
+
+Here's how to get the value of a Timestamp field.
+
+```
+@document["event.date"].value
+```
+
+## Output the default date & time
+
+The first way to display the Timestamp is to use the default format.
+
+Here's an example that shows how to do this by simply outputting the Timestamp value.
+
+```
+<span>
+  <%= @document["event.date"].value %>
+</span>
+# Outputs in the following format: 2016-01-23 13:30:00 +0000
+```
+
+## Other date formats
+
+You can control the format of the Timestamp value by using `strftime` method as shown below.
+
+```
+<span class="event-date">
+  <%= @document["event.date"].value.strftime("%A %b %d, %I:%M %P") %>
+</span>
+# Outputs in the following format: Saturday Jan 23, 01:30 pm
+```
+
+For more formatting options, explore the [Ruby documentation for the strftime method](https://ruby-doc.org/stdlib-2.4.1/libdoc/date/rdoc/Date.html#method-i-strftime).

--- a/docs-usage/03-templating/18-uid.md
+++ b/docs-usage/03-templating/18-uid.md
@@ -1,0 +1,11 @@
+# Templating the UID field
+
+The UID field is a unique identifier that can be used specifically to create SEO-friendly website URLs.
+
+## Usage
+
+Here's how you would get the UID value from the retrieved document object.
+
+```
+<p> Page uid: <%= @document.uid =></p>
+```

--- a/docs-usage/04-beyond-the-api/01-link-resolving.md
+++ b/docs-usage/04-beyond-the-api/01-link-resolving.md
@@ -1,0 +1,52 @@
+# Link Resolver
+
+When working with field types such as [Link](../03-templating/11-links-content-relationship.md) or [Rich Text](../03-templating/14-rich-text-title.md), the prismic.io Ruby kit will need to generate links to documents within your website.
+
+> **Before Reading**
+>
+> This page assumes that you have retrieved your content and stored it in a variable named `document`.
+
+Since routing is specific to your site, you will need to define your Link Resolver and provide it to some of the methods used on the fields.
+
+## Adding the Link Resolver function
+
+If you are incorporating prismic.io into your existing Ruby project or using the Ruby on Rails starter project, you will need to create a Link Resolver.
+
+Here is an example that shows how to add a Link Resolver function.
+
+```
+def link_resolver()
+  @link_resolver ||= Prismic::LinkResolver.new(nil) {|link|
+
+    # URL for the category type
+    if link.type == "category"
+      "/category/" + link.uid
+
+    # URL for the product type
+    elsif link.type == "product"
+      "/product/" + link.id
+
+    # Default case for all other types
+    else
+      "/"
+    end
+  }
+end
+```
+
+> A Link Resolver is provided in the [Ruby on Rails starter project](https://github.com/prismicio/ruby-rails-starter), but you may need to adapt it or write your own depending on how you've built your website app.
+>
+> The Link Resolver can be found in the `app/helpers/prismic_helper.rb` file of the Ruby on Rails starter.
+
+## Accessible attributes
+
+When creating your link resolver function, you will have access to certain attributes of the linked document.
+
+| Property                                                | Description                                             |
+| ------------------------------------------------------- | ------------------------------------------------------- |
+| <strong>link.id</strong><br/><code>string</code>        | <p>The document id</p>                                  |
+| <strong>link.uid</strong><br/><code>string</code>       | <p>The user-friendly unique id</p>                      |
+| <strong>link.type</strong><br/><code>string</code>      | <p>The custom type of the document</p>                  |
+| <strong>link.tags</strong><br/><code>array</code>       | <p>Array of the document tags</p>                       |
+| <strong>link.lang</strong><br/><code>string</code>      | <p>The language code of the document</p>                |
+| <strong>link.isBroken</strong><br/><code>boolean</code> | <p>Boolean that states if the link is broken or not</p> |

--- a/docs-usage/04-beyond-the-api/02-previews-and-the-toolbar.md
+++ b/docs-usage/04-beyond-the-api/02-previews-and-the-toolbar.md
@@ -1,0 +1,128 @@
+# Previews and the Prismic Toolbar
+
+When working in the writing room, you can preview new content on your website without having to publish the document, you can set up one or more websites where the content can be previewed. This allows you to have a production server, staging server, development server, etc.  Discover how to [handle multiple environments in Prismic](https://intercom.help/prismicio/prismic-io-basics/using-multiple-environments-of-one-prismic-repository).<br/>
+The Toolbar allows you to edit your pages. In your website, just click the button, select the part of the page that they want to edit, and you'll be redirected to the appropriate page in the Writing Room.
+
+> **Preview Activation for Older Repos**
+>
+> The current preview toolbar is enabled by default on all new Prismic repos. However, if you're on an older repo, you might be on older version of the toolbar. If your preview script `src` URL (described in Step 2, below) includes `new=true`, then your preview functionality includes an edit button. If the `src` does not include `new=true` and you would like the new preview toolbar, please [contact us via the Prismic forum](https://community.prismic.io/t/feature-activations-graphql-integration-fields-etc/847) so we can activate it for you.
+
+## 1. Configure Previews
+
+In your repository, navigate to **Settings > Previews**. Here you can add the configuration for a new preview, just add:
+
+- **The Site Name**: The name of the current site your configuring.
+- **Domain URL**: You can add the URL of your live website or a localhost domain, such as: http://localhost:8000.
+- **Link Resolver (optional) **: In order to be taken directly to the page you are previewing instead of the homepage, add a Link Resolver which is an endpoint on your server that takes a Prismic document and returns the url for that document. More details on step _4. Add a Link Resolver endpoint._
+
+![Preview configuration window screenshot.](https://images.prismic.io/prismicio-docs-v3/NThmYThkZWItOWU1ZS00YWRkLTk1N2QtYTBhNzc4MzI3MjVl_7090417a-cf3f-457d-8229-2f8bbc7af4aa_screenshot2020-09-13at20.34.27.pngautocompressformatrect00954834w700h612?auto=compress,format&rect=0,0,700,612&w=960&h=839)
+
+## 2. Include the Prismic Toolbar javascript file
+
+You will need to include the Prismic toolbar script **on every page of your website including your 404 page.**
+
+You can find the correct script in your repository **Settings** section, under the **Previews** tab.
+
+**Settings > Previews > Script**
+
+```
+<script async defer src="https://static.cdn.prismic.io/prismic.js?new=true&repo=your-repo-name”></script>
+```
+
+> **Correct repo name**
+>
+> Note: This example script has `your-repo-name` at the end of the URL, this value needs to be replaced with your repository name. You can find the correct script for in your repository's **Settings > Previews > Script.**
+
+> **Shearable Previews & unpublished previews**
+>
+> To guarantee that Shearable Preview links and unpublished document previews work properly, **you must ensure that these scripts are included on every page of your website, including your 404/Page Not Found page**. Otherwise, these previews might not work.
+
+## 3. Use the correct reference
+
+The next step is to make sure that the preview ref is used when you make your queries.
+
+When you preview your website, a preview cookie is generated that contains the preview token. This token can be used as a valid ref to make Prismic API queries. For any query you make on your website, make sure to check for the Preview cookie and use this preview ref in the query options if the preview cookie exists.
+
+The following example checks to see if there is a preview cookie. If there is, then it will set the `ref` variable to the preview ref. If not, it will use the experiment ref (if there is one) and otherwise the normal master ref (default published content).
+
+```
+def api
+  @api = Prismic.api('https://your-repo-name.cdn.prismic.io/api')
+end
+
+def ref
+  @ref ||= preview_ref || experiment_ref || api.master_ref.ref
+end
+
+def preview_ref
+  if request.cookies.has_key?(Prismic::PREVIEW_COOKIE)
+    request.cookies[Prismic::PREVIEW_COOKIE]
+  else
+    nil
+  end
+end
+
+def experiment_ref
+  if request.cookies.has_key?(Prismic::EXPERIMENTS_COOKIE)
+    api.experiments.ref_from_cookie(request.cookies[Prismic::EXPERIMENTS_COOKIE])
+  else
+    nil
+  end
+end
+```
+
+Then you just need to add the `"ref"` query option as shown below to ensure that the preview ref is used. Here is an example query:
+
+```
+document = api.getByUID("page", "about-us", { "ref" => ref })
+```
+
+That is all you need to do to gain the basic functionality of the Preview feature! With the basic functionality of the Preview feature, when you click on the preview button, you will be taken to the homepage of your preview domain. From here you can navigate to the page you are trying to preview.
+
+Next we will show you how to add a Link Resolver endpoint so that you will be taken directly to the page you are trying to preview.
+
+## 4. Add a Link Resolver endpoint
+
+In order to be taken directly to the page you are previewing instead of the homepage, you need to add a Link Resolver endpoint. A typical example of this would be:
+
+```bash
+http://{yoursite}/preview
+```
+
+In your preview settings add an endpoint to the optional Link Resolver field as explained in step 1.
+
+> **Using the official Prismic starter project?**
+>
+> If you are using the official Prismic [Ruby on Rails starter project](https://github.com/prismicio/ruby-rails-starter), then you should already have all the code in place that you need for Previews and the Prismic Toolbar!<br/>
+> If you are not using this kit to make your queries, then follow the rest of the steps below.
+
+Now you need to add the Link Resolver endpoint in your website application. When requested this endpoint must:
+
+- Retrieve the preview token from the `token` parameter in the query string
+- Call the Prismic development kit with this token and the [Link Resolver](../04-beyond-the-api/01-link-resolving.md) will retrieve the correct URL for the document being previewed
+- Redirect to the given URL
+
+> **The Preview Token**
+>
+> Note that the preview token will be a URL. You DO NOT need to follow this url. All you need to do is pass this token into the `preview_session`\*\* \*\*method as shown below
+
+Here is an example preview route:
+
+```
+# Preview
+def preview
+  api = Prismic.api('https://your-repo-name.cdn.prismic.io/api')
+  preview_token = params[:token]
+  redirect_url = api.preview_session(preview_token, link_resolver(), '/')
+  cookies[Prismic::PREVIEW_COOKIE] = { value: preview_token, expires: 30.minutes.from_now }
+  redirect_to redirect_url
+end
+```
+
+The example above uses a Link Resolver, `link_resolver()` , to determine the end url to redirect to. To learn more about how to set this up, check out our [Link Resolving](../04-beyond-the-api/01-link-resolving.md) page.
+
+Once all of these pieces are in place, your previews should be up and running!
+
+## 5. Troubleshooting
+
+Mistakes happen. [Luckily we've created an article for just that](https://user-guides.prismic.io/en/articles/3403530-troubleshooting-previews).

--- a/docs-usage/04-beyond-the-api/03-html-serializer.md
+++ b/docs-usage/04-beyond-the-api/03-html-serializer.md
@@ -1,0 +1,125 @@
+# HTML Serializer
+
+You can customize the HTML output of a Rich Text Field by incorporating an HTML Serializer into your project. This allows you to do things like adding custom classes to certain elements or modifying the way an element will be displayed.
+
+## Adding the HTML Serializer function
+
+To be able to modify the HTML output of a Rich Text, you need to first create the HTML Serializer function.
+
+It will need to identify the element by type and return the desired output.
+
+> Make sure to add a default case that returns `null`. This will leave all the other elements untouched.
+
+Here is an example of an HTML Serializer that will prevent image elements from being wrapped in paragraph tags and add a custom class to all hyperlink and paragraph elements.
+
+```
+html_serializer = Prismic.html_serializer do |element, html|
+
+  case element
+
+  # Add a custom class to paragraph elements
+  when Prismic::Fragments::StructuredText::Block::Paragraph
+    %(<p class="paragraph-class">#{html}</p>)
+
+  # Don't wrap images in a <p> tag
+  when Prismic::Fragments::StructuredText::Block::Image
+    %(<img src="#{element.url}" alt="#{element.alt}" width="#{element.width}" height="#{element.height}" />)
+
+  # Add a custom class to hyperlinks
+  when Prismic::Fragments::StructuredText::Span::Hyperlink
+    link = element.link
+    target = link.target.nil? ? "" : 'target="' + link.target + '" rel="noopener"'
+    if link.is_a? Prismic::Fragments::DocumentLink and link.broken
+      "<span>#{html}</span>"
+    else
+      %(<a class="link-class" href="#{link.url(link_resolver)}" #{target}>#{html}</a>)
+    end
+
+  # Return nil to stick with the default behavior
+  else
+    nil
+
+  end
+end
+```
+
+## Using the serializer function
+
+To use it, all you need to do is pass the Serializer function into the `as_html` method for a Rich Text element. Make sure to pass it in as the second parameter, the first being for the [Link Resolver](../04-beyond-the-api/01-link-resolving.md).
+
+```
+<%= @document["page.body_text"].as_html(link_resolver, html_serializer).html_safe %>
+```
+
+## Example with all elements
+
+Here is an example that shows you how to change all of the available Rich Text elements.
+
+```
+html_serializer = Prismic.html_serializer do |element, html|
+
+  case element
+
+  # Embed
+  when Prismic::Fragments::StructuredText::Block::Embed
+    %(<div data-oembed="#{element.url}" data-oembed-type="#{element.embed_type.downcase}" data-oembed-provider="#{element.provider.downcase}">#{element.html}</div>)
+
+  # Emphasis
+  when Prismic::Fragments::StructuredText::Span::Em
+    %(<em>#{html}</em>)
+
+  # Headings
+  when Prismic::Fragments::StructuredText::Block::Heading
+    %(<h#{element.level}>#{html}</h#{element.level}>)
+
+  # Hyperlink
+  when Prismic::Fragments::StructuredText::Span::Hyperlink
+    link = element.link
+    target = link.target.nil? ? "" : 'target="' + link.target + '" rel="noopener"'
+    if link.is_a? Prismic::Fragments::DocumentLink and link.broken
+      "<span>#{html}</span>"
+    else
+      %(<a href="#{link.url(link_resolver)}" #{target}>#{html}</a>)
+    end
+
+  # Image
+  when Prismic::Fragments::StructuredText::Block::Image
+    classes = ['block-img']
+    unless element.label.nil?
+      classes.push(element.label)
+    end
+    link = element.link_to
+    html = %(<img src="#{element.url}" alt="#{element.alt}" width="#{element.width}" height="#{element.height}" />)
+    unless link.nil?
+      target = link.target.nil? ? '' : 'target="' + link.target + '" rel="noopener"'
+      html = %(<a href="#{link.url(link_resolver)}" #{target}>#{html}</a>)
+    end
+    %(<p class="#{classes.join(' ')}">#{html}</p>)
+
+  # Label
+  when Prismic::Fragments::StructuredText::Span::Label
+    %(<span class=\"#{element.label}\">#{html}</span>)
+
+  # List Item
+  when Prismic::Fragments::StructuredText::Block::ListItem
+    %(<li>#{html}</li>)
+
+  # Paragraph
+  when Prismic::Fragments::StructuredText::Block::Paragraph
+    %(<p>#{html}</p>)
+
+  # Preformatted
+  when Prismic::Fragments::StructuredText::Block::Preformatted
+    %(<pre>#{html}</pre>)
+
+  # Strong
+  when Prismic::Fragments::StructuredText::Span::Strong
+    %(<strong>#{html}</strong>)
+
+  # Default case returns nil
+  else
+    nil
+  end
+
+end
+```

--- a/docs-usage/README.md
+++ b/docs-usage/README.md
@@ -1,0 +1,12 @@
+# Prismic with Ruby
+
+Documentation for `prismicio-community/ruby-kit` is organized into the following sections.
+
+- [**Getting Started**](./01-integrate-prismic-with-an-existing-project-ruby.md)
+- [**Query the API**](./02-query-the-api)
+- [**Templating**](./03-templating)
+- [**Beyond the API**](./04-beyond-the-api)
+
+To learn more about [Prismic](https://prismic.io), including documentation for other languages and frameworks, see the main Prismic Documentation site.
+
+[**Prismic Documentation**](https://prismic.io/docs)


### PR DESCRIPTION
This PR adds a local docs directory with PHP documentation from https://prismic.io/docs. The content from the website has been converted to Markdown so no content is lost.

Ruby documentation on https://prismic.io/docs will be removed. Documentation for this library should be updated as part of the repository.